### PR TITLE
support for qemu-img in a container

### DIFF
--- a/boxen/util/constants.go
+++ b/boxen/util/constants.go
@@ -1,7 +1,9 @@
 package util
 
 const (
-	MaxBuffer  = 65535
-	FilePerms  = 0666
-	QemuImgCmd = "qemu-img"
+	MaxBuffer        = 65535
+	FilePerms        = 0666
+	QemuImgCmd       = "qemu-img"
+	DockerCmd        = "docker"
+	QemuImgContainer = "ghcr.io/hellt/qemu-img:latest"
 )

--- a/boxen/util/files.go
+++ b/boxen/util/files.go
@@ -105,7 +105,7 @@ func CopyAsset(s, d string) error {
 	return err
 }
 
-// CommandExists checks if a command `cmd` exists in the PATH
+// CommandExists checks if a command `cmd` exists in the PATH.
 func CommandExists(cmd string) bool {
 	_, err := exec.LookPath(cmd)
 	return err == nil

--- a/boxen/util/files.go
+++ b/boxen/util/files.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -102,4 +103,10 @@ func CopyAsset(s, d string) error {
 	err = dest.Sync()
 
 	return err
+}
+
+// CommandExists checks if a command `cmd` exists in the PATH
+func CommandExists(cmd string) bool {
+	_, err := exec.LookPath(cmd)
+	return err == nil
 }


### PR DESCRIPTION
this PR proposes to remove the lock on having various binaries used in image build process by using containerization.

As I move along the code base, the first occurrence is the `qemu-img` that is used to copy the original disk provided by the user to a temp directory. 

The reason I used `hellt/qemu-img` as a container repo is that I failed to find a fresh version of qemu-img, hence I built it myself based on alpine in a straightforward way -- https://github.com/hellt/qemu-img-alpine