### PR TITLE
added `build` make target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+bin/*
 
 # Test binary, built with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
 .DEFAULT_GOAL := help
+BIN_DIR = $$(pwd)/bin
+BINARY = $$(pwd)/bin/boxen
+
+build: ## Build boxen
+	mkdir -p $(BIN_DIR)
+	go build -o $(BINARY) -ldflags="-s -w" main.go
 
 lint: ## Run linters
 	gofmt -w -s .


### PR DESCRIPTION
The `build` target allows to quickly build the boxen binary. The output dir is `./bin` to avoid the clash with the `boxen` dir that wraps the source code.