### PR TITLE
return err if scrapligo console not defined for platform

### DIFF
--- a/boxen/platforms/factory.go
+++ b/boxen/platforms/factory.go
@@ -1,6 +1,8 @@
 package platforms
 
 import (
+	"fmt"
+
 	"github.com/carlmontanari/boxen/boxen/config"
 	"github.com/carlmontanari/boxen/boxen/instance"
 
@@ -153,6 +155,8 @@ func NewPlatformFromConfig( //nolint:funlen
 			Qemu:           q,
 			ScrapliConsole: con,
 		}
+	default:
+		return nil, fmt.Errorf("scrapligo driver is not found for %q platform", pT)
 	}
 
 	return p, err

--- a/boxen/platforms/factory.go
+++ b/boxen/platforms/factory.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/carlmontanari/boxen/boxen/config"
 	"github.com/carlmontanari/boxen/boxen/instance"
+	"github.com/carlmontanari/boxen/boxen/util"
 
 	"github.com/scrapli/scrapligo/driver/base"
 )
@@ -156,7 +157,8 @@ func NewPlatformFromConfig( //nolint:funlen
 			ScrapliConsole: con,
 		}
 	default:
-		return nil, fmt.Errorf("scrapligo driver is not found for %q platform", pT)
+		return nil, fmt.Errorf("%w: scrapligo driver is not found for %q platform",
+			util.ErrAllocationError, pT)
 	}
 
 	return p, err


### PR DESCRIPTION
this is to indicate an error to a developer that scrapligo transport is not defined for the platform they are adding