### PR TITLE
mkisofs in a container

### DIFF
--- a/boxen/platforms/factory.go
+++ b/boxen/platforms/factory.go
@@ -60,7 +60,10 @@ func GetPlatformEmptyStruct(pT string) (Platform, error) {
 		return &IPInfusionOcNOS{}, nil
 	}
 
-	return nil, fmt.Errorf("%w: unknown platform type, this shouldn't happen", util.ErrValidationError)
+	return nil, fmt.Errorf(
+		"%w: unknown platform type, this shouldn't happen",
+		util.ErrValidationError,
+	)
 }
 
 func NewPlatformFromConfig( //nolint:funlen

--- a/boxen/util/constants.go
+++ b/boxen/util/constants.go
@@ -1,9 +1,12 @@
 package util
 
 const (
-	MaxBuffer        = 65535
-	FilePerms        = 0666
-	QemuImgCmd       = "qemu-img"
-	DockerCmd        = "docker"
-	QemuImgContainer = "ghcr.io/hellt/qemu-img:latest"
+	MaxBuffer          = 65535
+	FilePerms          = 0666
+	QemuImgCmd         = "qemu-img"
+	DockerCmd          = "docker"
+	QemuImgContainer   = "ghcr.io/hellt/qemu-img:latest"
+	ISOBinary          = "genisoimage"
+	DarwinISOBinary    = "mkisofs"
+	ISOBinaryContainer = "ghcr.io/hellt/cdrkit:1.11.11-r3"
 )


### PR DESCRIPTION
This PR makes boxen to use container image with mkisofs (based on https://github.com/hellt/dockerfiles/pkgs/container/cdrkit) if binary is not founds locally on the system

fix #8