### PR TITLE
added ttl-push make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,5 +16,9 @@ docker-lint: ## Run linters with docker
 	docker run -it --rm -v $$(pwd):/work ghcr.io/hellt/golines:0.8.0 golines -w .
 	docker run -it --rm -v $$(pwd):/app -w /app golangci/golangci-lint:v1.43.0 golangci-lint run --timeout 5m -v
 
+ttl-push: build ## push locally built binary to ttl.sh container registry
+	docker run --rm -v $$(pwd)/bin:/workspace ghcr.io/oras-project/oras:v0.12.0 push ttl.sh/boxen-$$(git rev-parse --short HEAD):1d ./boxen
+	@echo "download with: docker run --rm -v \$$(pwd):/workspace ghcr.io/oras-project/oras:v0.12.0 pull ttl.sh/boxen-$$(git rev-parse --short HEAD):1d"
+
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
this make target makes it possible to upload a locally built boxen binary to an anonymous ttl.sh container registry so that anyone on the internet can pull it

this is rather useful when an author wants to share an unreleased version of boxen (for example to let users test fixes before a new release gets published)

The workflow assumes that PR author runs `make ttl-push` the output presents an author with the following:

```
❯ make ttl-push 
mkdir -p $(pwd)/bin
go build -o $(pwd)/bin/boxen -ldflags="-s -w" main.go
docker run --rm -v $(pwd)/bin:/workspace ghcr.io/oras-project/oras:v0.12.0 push ttl.sh/boxen-$(git rev-parse --short HEAD):1d ./boxen
Uploading 08d9bddae28a boxen
Pushed ttl.sh/boxen-16e3885:1d
Digest: sha256:356e263bb588bb3adf7453a35d956f1c49b361c43d6524a90fdaaf9b614a7195
download with: docker run --rm -v $(pwd):/workspace ghcr.io/oras-project/oras:v0.12.0 pull ttl.sh/boxen-16e3885:1d
```

The last line can be shared with anyone to let them pull the binary (as an OCI artifact).

When users run this command, they will receive a binary in their PWD, making it super easy to use