### PR TITLE
Fix Boxen install script's parsing of latest release tag

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -80,7 +80,7 @@ setDesiredVersion() {
         # when desired version is not provided
         # get latest tag from the gh releases
         if type "curl" &>/dev/null; then
-            local latest_release_url=$(curl -s $REPO_URL/releases/latest | cut -d '"' -f 2)
+            local latest_release_url=$(curl -s -N https://api.github.com/repos/$REPO_NAME/releases/latest | sed '5q;d' | cut -d '"' -f 4)
             TAG=$(echo $latest_release_url | cut -d '"' -f 2 | awk -F "/" '{print $NF}')
             # tag with stripped `v` prefix
             TAG_WO_VER=$(echo "${TAG}" | cut -c 2-)


### PR DESCRIPTION
Fix #31, have `curl` parse the API endpoint of this repository's latest release tag.

Tested this on my machine and it works great:
```
christopher@ubuntu-vm:~/GitHub/boxen$ ./get.sh
No help topic for 'version'
A newer boxen 0.0.2 is available. Release notes: https://containerlab.srlinux.dev/rn/0.0.2
You are running containerlab  version
Proceed with upgrade? [Y/n]: Y
Downloading https://github.com/carlmontanari/boxen/releases/download/v0.0.2/boxen_0.0.2_linux_amd64.tar.gz
Preparing to install boxen 0.0.2 into /usr/local/bin
[sudo] password for christopher:
boxen installed into /usr/local/bin/boxen
        version: 0.0.2
        source: https://github.com/carlmontanari/boxen
```