### PR TITLE
Fix Boxen update script's check for current installed version of Boxen

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -112,7 +112,7 @@ setDesiredVersion() {
 # if it needs to be changed.
 checkInstalledVersion() {
     if [[ -f "${BIN_INSTALL_DIR}/${BINARY_NAME}" ]]; then
-        local version=$("${BIN_INSTALL_DIR}/${BINARY_NAME}" version | grep version | awk '{print $NF}')
+        local version=$("${BIN_INSTALL_DIR}/${BINARY_NAME}" --version | grep version | awk '{print $NF}')
         if [[ "v$version" == "$TAG" ]]; then
             echo "${BINARY_NAME} is already at ${DESIRED_VERSION:-latest ($version)}" version
             return 0


### PR DESCRIPTION
get.sh attempts to run `boxen version`, which is an invalid command. get.sh should run `boxen --version` instead.

Don't have an easy way to test this bugfix, but subsequent logic should work fine based on the following:
```
christopher@ubuntu-vm:~$ boxen --version | grep version | awk '{print $NF}'
0.0.3
```