### PR TITLE
user defined ports for packaging workflow

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -22,3 +22,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.45
+      - name: install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+      - name: tests
+        run: make test-race

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -4,7 +4,7 @@ name: Commit
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  lint:
+  unit-test:
     runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 2

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,12 @@ docker-lint: ## Run linters with docker
 	docker run -it --rm -v $$(pwd):/work ghcr.io/hellt/golines:0.8.0 golines -w .
 	docker run -it --rm -v $$(pwd):/app -w /app golangci/golangci-lint:v1.45.0 golangci-lint run --timeout 5m -v
 
+test: ## Run unit tests
+	gotestsum --format testname --hide-summary=skipped -- -coverprofile=cover.out ./...
+
+test-race: ## Run unit tests with race flag
+	gotestsum --format testname --hide-summary=skipped -- -coverprofile=cover.out ./... -race
+
 ttl-push: build ## push locally built binary to ttl.sh container registry
 	docker run --rm -v $$(pwd)/bin:/workspace ghcr.io/oras-project/oras:v0.12.0 push ttl.sh/boxen-$$(git rev-parse --short HEAD):1d ./boxen
 	@echo "download with: docker run --rm -v \$$(pwd):/workspace ghcr.io/oras-project/oras:v0.12.0 pull ttl.sh/boxen-$$(git rev-parse --short HEAD):1d"

--- a/boxen/boxen/mgmtnet.go
+++ b/boxen/boxen/mgmtnet.go
@@ -1,0 +1,35 @@
+package boxen
+
+import "github.com/carlmontanari/boxen/boxen/config"
+
+const (
+	// host port base number, instance ports are incremented from this value
+	hostPortBase = 48000
+)
+
+// zipPlatformProfileNats receives the lists of TCP and UDP ports that are defined in a platform profile yaml.
+// For each received tcp/udp instance port a host port is allocated sequentially from the hostPortBase port number.
+// These port mappings are used in packaging workflow (e.g. when building for containerlab)
+func zipPlatformProfileNats(platformTCPPorts, platformUDPPorts []int) (tcpNats, udpNats []*config.NatPortPair) {
+	tcpPortsLen := len(platformTCPPorts)
+	udpPortsLen := len(platformUDPPorts)
+
+	tcpNats = make([]*config.NatPortPair, 0, tcpPortsLen)
+	udpNats = make([]*config.NatPortPair, 0, udpPortsLen)
+
+	for i, tcp := range platformTCPPorts {
+		tcpNats = append(tcpNats, &config.NatPortPair{
+			InstanceSide: tcp,
+			HostSide:     hostPortBase + i,
+		})
+	}
+
+	for i, udp := range platformUDPPorts {
+		udpNats = append(udpNats, &config.NatPortPair{
+			InstanceSide: udp,
+			HostSide:     hostPortBase + tcpPortsLen + i,
+		})
+	}
+
+	return
+}

--- a/boxen/boxen/mgmtnet.go
+++ b/boxen/boxen/mgmtnet.go
@@ -3,14 +3,16 @@ package boxen
 import "github.com/carlmontanari/boxen/boxen/config"
 
 const (
-	// host port base number, instance ports are incremented from this value
+	// host port base number, instance ports are incremented from this value.
 	hostPortBase = 48000
 )
 
-// zipPlatformProfileNats receives the lists of TCP and UDP ports that are defined in a platform profile yaml.
-// For each received tcp/udp instance port a host port is allocated sequentially from the hostPortBase port number.
-// These port mappings are used in packaging workflow (e.g. when building for containerlab)
-func zipPlatformProfileNats(
+// ZipPlatformProfileNats receives the lists of TCP and UDP ports
+// that are defined in a platform profile yaml.
+// For each received tcp/udp instance port a host port is allocated sequentially
+// from the hostPortBase port number.
+// These port mappings are used in packaging workflow (e.g. when building for containerlab).
+func ZipPlatformProfileNats(
 	platformTCPPorts, platformUDPPorts []int,
 ) (tcpNats, udpNats []*config.NatPortPair) {
 	tcpPortsLen := len(platformTCPPorts)

--- a/boxen/boxen/mgmtnet.go
+++ b/boxen/boxen/mgmtnet.go
@@ -10,7 +10,9 @@ const (
 // zipPlatformProfileNats receives the lists of TCP and UDP ports that are defined in a platform profile yaml.
 // For each received tcp/udp instance port a host port is allocated sequentially from the hostPortBase port number.
 // These port mappings are used in packaging workflow (e.g. when building for containerlab)
-func zipPlatformProfileNats(platformTCPPorts, platformUDPPorts []int) (tcpNats, udpNats []*config.NatPortPair) {
+func zipPlatformProfileNats(
+	platformTCPPorts, platformUDPPorts []int,
+) (tcpNats, udpNats []*config.NatPortPair) {
 	tcpPortsLen := len(platformTCPPorts)
 	udpPortsLen := len(platformUDPPorts)
 

--- a/boxen/boxen/mgmtnet_test.go
+++ b/boxen/boxen/mgmtnet_test.go
@@ -1,8 +1,9 @@
-package boxen
+package boxen_test
 
 import (
 	"testing"
 
+	"github.com/carlmontanari/boxen/boxen/boxen"
 	"github.com/carlmontanari/boxen/boxen/config"
 	"github.com/google/go-cmp/cmp"
 )
@@ -70,7 +71,7 @@ func TestZipPlatformProfileNats(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			tcp, udp := zipPlatformProfileNats(tt.tcp, tt.udp)
+			tcp, udp := boxen.ZipPlatformProfileNats(tt.tcp, tt.udp)
 
 			if !cmp.Equal(tcp, tt.wantTCPNats) {
 				t.Fatalf(
@@ -91,6 +92,5 @@ func TestZipPlatformProfileNats(t *testing.T) {
 			}
 		},
 		)
-
 	}
 }

--- a/boxen/boxen/mgmtnet_test.go
+++ b/boxen/boxen/mgmtnet_test.go
@@ -1,0 +1,96 @@
+package boxen
+
+import (
+	"testing"
+
+	"github.com/carlmontanari/boxen/boxen/config"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestZipPlatformProfileNats(t *testing.T) {
+	tests := []struct {
+		desc        string
+		tcp         []int
+		udp         []int
+		wantTCPNats []*config.NatPortPair
+		wantUDPNats []*config.NatPortPair
+	}{
+		{
+			desc: "two tcp ports and one udp",
+			tcp:  []int{22, 23},
+			udp:  []int{161},
+			wantTCPNats: []*config.NatPortPair{
+				{
+					InstanceSide: 22,
+					HostSide:     48000,
+				},
+				{
+					InstanceSide: 23,
+					HostSide:     48001,
+				},
+			},
+			wantUDPNats: []*config.NatPortPair{
+				{
+					InstanceSide: 161,
+					HostSide:     48002,
+				},
+			},
+		},
+		{
+			desc: "two tcp ports and no udp",
+			tcp:  []int{22, 23},
+			wantTCPNats: []*config.NatPortPair{
+				{
+					InstanceSide: 22,
+					HostSide:     48000,
+				},
+				{
+					InstanceSide: 23,
+					HostSide:     48001,
+				},
+			},
+			wantUDPNats: []*config.NatPortPair{},
+		},
+		{
+			desc:        "no tcp ports and two udp",
+			udp:         []int{161, 200},
+			wantTCPNats: []*config.NatPortPair{},
+			wantUDPNats: []*config.NatPortPair{
+				{
+					InstanceSide: 161,
+					HostSide:     48000,
+				},
+				{
+					InstanceSide: 200,
+					HostSide:     48001,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			tcp, udp := zipPlatformProfileNats(tt.tcp, tt.udp)
+
+			if !cmp.Equal(tcp, tt.wantTCPNats) {
+				t.Fatalf(
+					"%s: actual and expected inputs do not match\nactual: %+v\nexpected:%+v",
+					tt.desc,
+					tcp,
+					tt.wantTCPNats,
+				)
+			}
+
+			if !cmp.Equal(udp, tt.wantUDPNats) {
+				t.Fatalf(
+					"%s: actual and expected inputs do not match\nactual: %+v\nexpected:%+v",
+					tt.desc,
+					udp,
+					tt.wantUDPNats,
+				)
+			}
+		},
+		)
+
+	}
+}

--- a/boxen/boxen/packagebuild.go
+++ b/boxen/boxen/packagebuild.go
@@ -118,7 +118,10 @@ func (b *Boxen) packageBundle(
 		return err
 	}
 
-	tcpNats, udpNats := zipPlatformProfileNats(platformDefaultProfile.TPCNatPorts, platformDefaultProfile.UDPNatPorts)
+	tcpNats, udpNats := zipPlatformProfileNats(
+		platformDefaultProfile.TPCNatPorts,
+		platformDefaultProfile.UDPNatPorts,
+	)
 
 	c.Instances[i.srcDisk.PlatformType] = &config.Instance{
 		Name:         i.srcDisk.PlatformType,

--- a/boxen/boxen/packagebuild.go
+++ b/boxen/boxen/packagebuild.go
@@ -118,6 +118,8 @@ func (b *Boxen) packageBundle(
 		return err
 	}
 
+	tcpNats, udpNats := zipPlatformProfileNats(platformDefaultProfile.TPCNatPorts, platformDefaultProfile.UDPNatPorts)
+
 	c.Instances[i.srcDisk.PlatformType] = &config.Instance{
 		Name:         i.srcDisk.PlatformType,
 		PlatformType: i.srcDisk.PlatformType,
@@ -129,8 +131,8 @@ func (b *Boxen) packageBundle(
 		Hardware:     platformDefaultProfile.Hardware.ToHardware(),
 		MgmtIntf: &config.MgmtIntf{
 			Nat: &config.Nat{
-				TCP: zipDefaultTCPNats(platformDefaultProfile.TPCNatPorts),
-				UDP: zipDefaultUDPNats(platformDefaultProfile.UDPNatPorts),
+				TCP: tcpNats,
+				UDP: udpNats,
 			},
 			Bridge: nil,
 		},

--- a/boxen/boxen/packagebuild.go
+++ b/boxen/boxen/packagebuild.go
@@ -118,7 +118,7 @@ func (b *Boxen) packageBundle(
 		return err
 	}
 
-	tcpNats, udpNats := zipPlatformProfileNats(
+	tcpNats, udpNats := ZipPlatformProfileNats(
 		platformDefaultProfile.TPCNatPorts,
 		platformDefaultProfile.UDPNatPorts,
 	)

--- a/boxen/config/interfaces.go
+++ b/boxen/config/interfaces.go
@@ -1,5 +1,7 @@
 package config
 
+import "fmt"
+
 type MgmtIntf struct {
 	Nat    *Nat
 	Bridge *Bridge
@@ -13,6 +15,10 @@ type Nat struct {
 type NatPortPair struct {
 	InstanceSide int `yaml:"instance_side,omitempty"`
 	HostSide     int `yaml:"host_side,omitempty"`
+}
+
+func (n *NatPortPair) String() string {
+	return fmt.Sprintf("(host)%d<->%d(instance)", n.HostSide, n.InstanceSide)
 }
 
 type Bridge struct{}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/carlmontanari/difflibgo v0.0.0-20210718194309-31b9e131c298 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d // indirect
 	github.com/creack/pty v1.1.18 // indirect
+	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/russross/blackfriday/v2 v2.0.1 // indirect
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/sirikothe/gotextfsm v1.0.1-0.20200816110946-6aa2cfd355e4 // indirect


### PR DESCRIPTION
this PR adds the ability for boxen to generate tcp/udp nat port pairs based on what was defined in a platform profile.

Ports are sequentially added from a base number of 48000. This ofc can only be applicable to the packaging workflow where qemu instances are isolated in a node-specific container