### PR TITLE
fix check point image recognition

### DIFF
--- a/boxen/platforms/util.go
+++ b/boxen/platforms/util.go
@@ -29,6 +29,10 @@ func diskToVendorPlatformMap() map[*regexp.Regexp][]string {
 			"paloalto",
 			"panos",
 		},
+		regexp.MustCompile(`(?i)check_point_r.*.cloudguard.*.qcow2`): {
+			"checkpoint",
+			"cloudguard",
+		},
 	}
 }
 
@@ -63,12 +67,12 @@ func pTDiskToVersionMap() map[string]*regexp.Regexp {
 		),
 		PlatformTypePaloAltoPanos: regexp.MustCompile(
 			`(?i)(?:pa-vm-kvm-)(\d+\.\d+\.\d+).qcow2`),
+		PlatformTypeCheckpointCloudguard: regexp.MustCompile(
+			`(?i)check_point_(r\d+\.\d+)_cloudguard_.*.qcow2`),
 	}
 }
 
-func GetDiskVersion(
-	f, pT string,
-) (string, error) {
+func GetDiskVersion(f, pT string) (string, error) {
 	targetVersionMap := pTDiskToVersionMap()
 
 	pattern := targetVersionMap[pT]


### PR DESCRIPTION
# Summary

## Issue

Running `boxen --disk <check_point_image>` command fails with:

```console
failed gleaning source data from disk
```

This PR adds a fix by:

  - Adding required  `Vendor Platform Map` values
  - Adding required `Disk Version Map` values