### PR TITLE
Fix panos 

### DIFF
--- a/boxen/platforms/paloaltopanos.go
+++ b/boxen/platforms/paloaltopanos.go
@@ -18,7 +18,7 @@ const (
 	PaloAltoPanosScrapliPlatform = "paloalto_panos"
 
 	paloAltoPanosDefaultBootTime   = 720
-	paloAltoPanosDefaultPromptWait = 30
+	paloAltoPanosDefaultPromptWait = 300
 	paloAltoPanosDefaultLoginWait  = 300
 )
 

--- a/boxen/platforms/paloaltopanos.go
+++ b/boxen/platforms/paloaltopanos.go
@@ -18,7 +18,7 @@ const (
 	PaloAltoPanosScrapliPlatform = "paloalto_panos"
 
 	paloAltoPanosDefaultBootTime   = 720
-	paloAltoPanosDefaultPromptWait = 300
+	paloAltoPanosDefaultPromptWait = 30
 	paloAltoPanosDefaultLoginWait  = 300
 )
 

--- a/boxen/platforms/util.go
+++ b/boxen/platforms/util.go
@@ -66,7 +66,7 @@ func pTDiskToVersionMap() map[string]*regexp.Regexp {
 			`(?i)(?:junos-media-vsrx-x86-64-vmdisk-|media-vsrx-vmdisk-)(\d+\.[\w-]+\.\d+).qcow2`,
 		),
 		PlatformTypePaloAltoPanos: regexp.MustCompile(
-			`(?i)(?:pa-vm-kvm-)(\d+\.\d+\.\d+).qcow2`),
+			`(?i)(?:pa-vm-kvm-)(\d+\.\d+\.\d+(?:-h\d+)?).qcow2`),
 		PlatformTypeCheckpointCloudguard: regexp.MustCompile(
 			`(?i)check_point_(r\d+\.\d+)_cloudguard_.*.qcow2`),
 	}


### PR DESCRIPTION
### Summary
## Issue
Running boxen to build PAN-OS VM errors out:
```
henri@containerlab boxen]$ sudo bin/boxen package --disk ~/Projects/disks/PA-VM-KVM-10.2.10-h12.qcow2 
        ⠈ map[csr1000v-.*.qcow2:[cisco csr1000v] (?i)xrv9k-fullk9-x.*.qcow2:[cisco xrv9k] (?i)(nexus9300v(?:64)?|nxosv).*.qcow2:[cisco n9kv] (?i)vEOS-lab-.*.vmdk:[arista veos] (?i)(junos-media-vsrx-x86-64|media-vsrx)-vmdisk.*.qcow2:[juniper vsrx] (?i)PA-VM-KVM.*.qcow2:[paloalto panos] (?i)check_point_r.*.cloudguard.*.qcow2:[checkpoint cloudguard]]
      info   1738144370 package requested for disk '/home/henri/Projects/disks/PA-VM-KVM-10.2.10-h12.qcow2'
  critical   1738144370 failed gleaning source data from disk '/home/henri/Projects/disks/PA-VM-KVM-10.2.10-h12.qcow2'
  critical   1738144370 error allocating disks for packaging: inspectionError: failed gleaning source data from disk '/home/henri/Projects/disks/PA-VM-KVM-10.2.10-h12.qcow2'
        🆘 finished unsuccessfully in 0 seconds 
inspectionError: failed gleaning source data from disk '/home/henri/Projects/disks/PA-VM-KVM-10.2.10-h12.qcow2'
```
It worked when PA-VM was renamed to ``PA-VM-KVM-10.2.10.qcow2``.

## Fix

This PR fixes the regex that was used to extract version for PAN-OS image and properly include hotfix version. Seems that vendor regex already did that.
