### PR TITLE
Fail early on bad disk path and allow version mismatch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ build:
 build-image:
 	docker build \
         -f build/agent.Dockerfile \
-        -t ghcr.io/carlmontanari/boxen:dev-latest .
+        -t ghcr.io/carlmontanari/boxen:0.0.0 .
         # .	\
         # --platform \
         # linux/amd64 .

--- a/boxen/build.go
+++ b/boxen/build.go
@@ -3,6 +3,7 @@ package boxen
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -38,9 +39,20 @@ func (b *Boxen) Build(
 		platform,
 	)
 
-	b.disk = diskImage
+	b.disk = boxenutil.MustExpandPath(diskImage)
 
-	var err error
+	diskInfo, err := os.Stat(b.disk)
+	if err != nil {
+		b.l.Error("failed resolving disk image", "disk", b.disk, "error", err.Error())
+
+		return fmt.Errorf("%w: disk image %q not found: %w", boxenerrors.ErrBoxen, b.disk, err)
+	}
+
+	if diskInfo.IsDir() {
+		b.l.Error("disk image path is a directory", "disk", b.disk)
+
+		return fmt.Errorf("%w: disk image %q is a directory", boxenerrors.ErrBoxen, b.disk)
+	}
 
 	b.p, err = b.resolveProfile(profile)
 	if err != nil {

--- a/boxen/platform.go
+++ b/boxen/platform.go
@@ -123,6 +123,17 @@ func (b *Boxen) resolveVersion() error {
 	}
 
 	matches := versionRe.FindStringSubmatch(filepath.Base(b.disk))
+	if len(matches) == 0 {
+		b.l.Warn(
+			"version pattern did not match the disk string, skipping version resolution",
+			"pattern",
+			b.p.VersionPattern,
+			"disk",
+			filepath.Base(b.disk),
+		)
+
+		return nil
+	}
 
 	if len(matches) > 1 {
 		b.p.ResolvedVersion = matches[1]


### PR DESCRIPTION
When the disk path is leading to void, we used to do more work than we should've.
Failing early.