### PR TITLE
Prompts names

### DIFF
--- a/agent/process.go
+++ b/agent/process.go
@@ -15,8 +15,9 @@ import (
 )
 
 func promptCallbackName(idx int, p boxenprofile.Prompt) string {
-	if name := strings.TrimSpace(p.Name); name != "" {
-		return fmt.Sprintf("prompts step name %q, idx %d", name, idx)
+	name := strings.TrimSpace(p.Name)
+	if name != "" {
+		return fmt.Sprintf("prompts step name: %s, idx: %d", name, idx)
 	}
 
 	return fmt.Sprintf("prompts step idx %d", idx)

--- a/agent/process.go
+++ b/agent/process.go
@@ -14,6 +14,14 @@ import (
 	scrapligocli "github.com/scrapli/scrapligo/v2/cli"
 )
 
+func promptCallbackName(idx int, p boxenprofile.Prompt) string {
+	if name := strings.TrimSpace(p.Name); name != "" {
+		return fmt.Sprintf("prompts step name %q, idx %d", name, idx)
+	}
+
+	return fmt.Sprintf("prompts step idx %d", idx)
+}
+
 func (a *Agent) processStepPrompts(ctx context.Context, step *boxenprofile.Step) error {
 	t, err := time.ParseDuration(step.Prompts.Timeout)
 	if err != nil {
@@ -33,8 +41,12 @@ func (a *Agent) processStepPrompts(ctx context.Context, step *boxenprofile.Step)
 	cbs := make([]*scrapligocli.ReadCallback, len(step.Prompts.Prompts))
 
 	for idx, p := range step.Prompts.Prompts {
+		cbName := promptCallbackName(idx, p)
+
 		a.l.Debug(
 			"building prompts callback",
+			"callback name",
+			cbName,
 			"prompt",
 			p.Prompt,
 			"response",
@@ -79,8 +91,6 @@ func (a *Agent) processStepPrompts(ctx context.Context, step *boxenprofile.Step)
 				scrapligocli.WithCompletes(),
 			)
 		}
-
-		cbName := fmt.Sprintf("prompts step idx %d", idx)
 
 		cbs[idx] = scrapligocli.NewReadCallback(
 			cbName,

--- a/agent/process_test.go
+++ b/agent/process_test.go
@@ -19,7 +19,7 @@ func TestPromptCallbackName(t *testing.T) {
 			prompt: boxenprofile.Prompt{
 				Name: "login prompt",
 			},
-			expected: `prompts step name "login prompt", idx 3`,
+			expected: `prompts step name: login prompt, idx: 3`,
 		},
 		{
 			name:     "unnamed prompt",

--- a/agent/process_test.go
+++ b/agent/process_test.go
@@ -1,0 +1,50 @@
+package agent
+
+import (
+	"testing"
+
+	boxenprofile "github.com/carlmontanari/boxen/profile"
+)
+
+func TestPromptCallbackName(t *testing.T) {
+	cases := []struct {
+		name     string
+		idx      int
+		prompt   boxenprofile.Prompt
+		expected string
+	}{
+		{
+			name: "named prompt",
+			idx:  3,
+			prompt: boxenprofile.Prompt{
+				Name: "login prompt",
+			},
+			expected: `prompts step name "login prompt", idx 3`,
+		},
+		{
+			name:     "unnamed prompt",
+			idx:      4,
+			expected: "prompts step idx 4",
+		},
+		{
+			name: "blank prompt name",
+			idx:  5,
+			prompt: boxenprofile.Prompt{
+				Name: " \t\n ",
+			},
+			expected: "prompts step idx 5",
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(
+			testCase.name,
+			func(t *testing.T) {
+				actual := promptCallbackName(testCase.idx, testCase.prompt)
+				if actual != testCase.expected {
+					t.Fatalf("prompt callback name incorrect, got %q, want %q", actual, testCase.expected)
+				}
+			},
+		)
+	}
+}

--- a/profile/common.go
+++ b/profile/common.go
@@ -73,6 +73,8 @@ type StepPrompts struct {
 
 // Prompt defines how we match on a prompt and what we respond to it.
 type Prompt struct {
+	// Prompt name is optional, prompt index is used if name is not set
+	Name     string   `yaml:"name"`
 	Prompt   Contains `yaml:"prompt"`
 	Response string   `yaml:"response"`
 	// if marked hidden we wont read the inputs we send off the channel, use this for


### PR DESCRIPTION
> rebase after #54 as it builds on top of it

Adds prompt names for easier tracking of prompts in the logs:


```
31 May 26 01:11 EEST INFO builder message: callback triggered {
  "callback name": "prompts step name \"enter initial login\", idx 0"
}
```