### PR TITLE
Volumes with /boot and /lib/modules for virt-sparsify to work in the builder image

### DIFF
--- a/agent/package.go
+++ b/agent/package.go
@@ -440,7 +440,7 @@ func (a *Agent) packageShrinkify(ctx context.Context) error {
 
 	args := []string{"fat.qcow2", "--compress", "disk.qcow2"}
 
-	a.l.Info("starting sparsify", "command", sparsifyBinary, "args", args)
+	a.l.Info("starting disk sparsify, this can take 10+ minutes...", "command", sparsifyBinary, "args", args)
 
 	cmd := exec.CommandContext(ctx, sparsifyBinary, args...)
 

--- a/boxen/build.go
+++ b/boxen/build.go
@@ -85,6 +85,7 @@ func (b *Boxen) Build(
 			Image: buildGetBuilderImage(),
 			// Platform: platform,
 			Env:      buildBuilderEnv(ourAddr, vmConsole),
+			Volumes:  buildBuilderVolumes(),
 			Detached: true,
 			// dont remove! we'll be committing the image to our new final image
 			// once the packaging process is complete
@@ -193,6 +194,14 @@ func buildBuilderEnv(host string, vmConsole bool) []string {
 	}
 
 	return env
+}
+
+func buildBuilderVolumes() []string {
+	return []string{
+		// boot and modules are required for virt-sparsify to work
+		"/boot:/boot:ro",
+		"/lib/modules:/lib/modules:ro",
+	}
 }
 
 func (b *Boxen) openVMConsole(ctx context.Context, containerID string) error {

--- a/boxen/build_test.go
+++ b/boxen/build_test.go
@@ -40,6 +40,19 @@ func TestBuildBuilderEnvVMConsole(t *testing.T) {
 	}
 }
 
+func TestBuildBuilderVolumes(t *testing.T) {
+	volumes := buildBuilderVolumes()
+
+	for _, volume := range []string{
+		"/boot:/boot:ro",
+		"/lib/modules:/lib/modules:ro",
+	} {
+		if !slices.Contains(volumes, volume) {
+			t.Fatalf("builder volumes missing mount, got %v, want %q", volumes, volume)
+		}
+	}
+}
+
 func TestBuildConsoleAttachCommand(t *testing.T) {
 	actual := buildOpenConsoleCommand("container-id")
 	expected := "docker exec -i -t container-id telnet localhost 5001"

--- a/container/docker/run.go
+++ b/container/docker/run.go
@@ -46,6 +46,10 @@ func (r *Runtime) Run(
 		args = append(args, "-e", env)
 	}
 
+	for _, volume := range cfg.Volumes {
+		args = append(args, "-v", volume)
+	}
+
 	if cfg.Detached {
 		args = append(args, "-d")
 	}

--- a/container/types/run.go
+++ b/container/types/run.go
@@ -6,6 +6,7 @@ type RunConfig struct {
 	Image      string
 	Platform   string
 	Env        []string
+	Volumes    []string
 	Detached   bool
 	Remove     bool
 	Privileged bool


### PR DESCRIPTION
fix #57 