### PR TITLE
Management Passthrough (aka Transparent managment) datapath

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ run:
       write:
         content: |
           nv set interface eth0 ipv4 address {{ .mgmtIPv4 }}
-          nv set interface eth0 ipv4 gateway {{ .mgmtGatewayIPv4 }}
+          nv set interface eth0 ipv4 gateway {{ .mgmtIPv4Gateway }}
 ```
 
 The following values are available:
@@ -91,12 +91,12 @@ The following values are available:
 | `{{ .mgmtIPv4Address }}`   | `172.20.20.10`              | IPv4 management address without prefix length.     |
 | `{{ .mgmtIPv4PrefixLen }}` | `24`                        | IPv4 management prefix length.                     |
 | `{{ .mgmtIPv4Network }}`   | `172.20.20.0/24`            | IPv4 management network in CIDR notation.          |
-| `{{ .mgmtGatewayIPv4 }}`   | `172.20.20.1`               | IPv4 management default gateway.                   |
+| `{{ .mgmtIPv4Gateway }}`   | `172.20.20.1`               | IPv4 management default gateway.                   |
 | `{{ .mgmtIPv6 }}`          | `2001:db8:20::10/64`        | IPv6 management address in CIDR notation.          |
 | `{{ .mgmtIPv6Address }}`   | `2001:db8:20::10`           | IPv6 management address without prefix length.     |
 | `{{ .mgmtIPv6PrefixLen }}` | `64`                        | IPv6 management prefix length.                     |
 | `{{ .mgmtIPv6Network }}`   | `2001:db8:20::/64`          | IPv6 management network in CIDR notation.          |
-| `{{ .mgmtGatewayIPv6 }}`   | `2001:db8:20::1`            | IPv6 management default gateway.                   |
+| `{{ .mgmtIPv6Gateway }}`   | `2001:db8:20::1`            | IPv6 management default gateway.                   |
 
 In packaging and legacy host-forwarded management mode, management template
 values resolve to the QEMU user-network defaults (`10.0.0.15/24` and
@@ -111,7 +111,7 @@ content: |
   nv set interface eth0 ipv4 address dhcp
   {{ else }}
   nv set interface eth0 ipv4 address {{ .mgmtIPv4 }}
-  nv set interface eth0 ipv4 gateway {{ .mgmtGatewayIPv4 }}
+  nv set interface eth0 ipv4 gateway {{ .mgmtIPv4Gateway }}
   {{ end }}
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 
 boxen -- put your network operating systems in a box (or if you speak 🇩🇪, fight them! 🤣)!
 
-boxen is a cli tool written in Go that allows you to package your network operating systems neatly 
-into little... boxes (container images) so they are easily portable, and, most importantly, so you 
+boxen is a cli tool written in Go that allows you to package your network operating systems neatly
+into little... boxes (container images) so they are easily portable, and, most importantly, so you
 can use them with the wonderful [containerlab](https://github.com/srl-labs/containerlab).
 
 ## Attach to a VM console
@@ -24,3 +24,87 @@ boxen build --disk /path/to/disk.qcow2 --profile /path/to/profile.yaml --vm-cons
 ```
 
 Since the telnet client is used to attach to the VM console, to exit it, type `Ctrl+]` followed by `q`.
+
+## Transparent Management
+
+By default, Boxen connects the VM management interface with QEMU user networking.
+In that mode, the VM receives the fixed management address `10.0.0.15/24`, uses
+`10.0.0.2` as its gateway, and the ports a user wants to forward to the VM are driven by the
+QEMU `hostfwd` rules defined in `virtualMachine.natPorts`.  
+This operational mode, however, has several shortcomings:
+
+- The management IP address configured in the Network Operating System config is static and different from the one assigned to the container management interface by containerlab. This makes every NOS see the same management IP and makes external management systems confused when the nodes report their IP during the onboarding/call-home process.
+- The exposed ports are a fixed set of ports provided by the user and are only forwarded via IPv4 address family due to QEMU limitations. This makes it impossible to forward ports via IPv6 easily.
+
+To solve for these limitations, Boxen offers transparent management mode that can be enabled in the profile by setting:
+
+```yaml
+virtualMachine:
+  managementPassthrough: true
+```
+
+When transparent management is enabled at runtime, Boxen connects the VM
+management NIC to `tap0` and redirects traffic between container `eth0` and
+`tap0` with `tc`. The network OS can then use the same management IP address
+that containerlab assigned to the container management interface. In this mode,
+QEMU management `hostfwd` rules are simply not created.
+
+`CLAB_MGMT_PASSTHROUGH` environment variable overrides the profile setting at runtime. Note, that this env var must be set in the container's shell, not on your host.
+
+- `CLAB_MGMT_PASSTHROUGH=true` enables transparent management.
+- `CLAB_MGMT_PASSTHROUGH=false` forces legacy host-forwarded management.
+- If unset, `virtualMachine.managementPassthrough` controls the behavior.
+
+Packaging and `boxen build --vm-console` always use the legacy QEMU user-network
+management path because containerlab is not providing the transparent management
+datapath during image build.
+
+## Process Types
+
+## Write
+
+Write content uses Go template variables. Templates work in the following fields:
+`write.content`, `write.contentFromFile`, and `write.contentFromStartupConfig`.
+
+```yaml
+run:
+  process:
+    - type: write
+      write:
+        content: |
+          nv set interface eth0 ipv4 address {{ .mgmtIPv4 }}
+          nv set interface eth0 ipv4 gateway {{ .mgmtGatewayIPv4 }}
+```
+
+The following values are available:
+
+| Template value             | Example value               | Description                                        |
+| -------------------------- | --------------------------- | -------------------------------------------------- |
+| `{{ .disk }}`              | `disk.qcow2`                | Disk filename used inside the agent container.     |
+| `{{ .version }}`           | `5.15.0`                    | Version matched from the profile `versionPattern`. |
+| `{{ .extraFiles }}`        | `[license.lic startup.cfg]` | List of extra file basenames.                      |
+| `{{ .username }}`          | `admin`                     | Containerlab-provided username during run.         |
+| `{{ .password }}`          | `admin`                     | Containerlab-provided password during run.         |
+| `{{ .hostname }}`          | `leaf1`                     | Containerlab node hostname during run.             |
+| `{{ .mgmtIPv4 }}`          | `172.20.20.10/24`           | IPv4 management address in CIDR notation.          |
+| `{{ .mgmtIPv4Address }}`   | `172.20.20.10`              | IPv4 management address without prefix length.     |
+| `{{ .mgmtIPv4PrefixLen }}` | `24`                        | IPv4 management prefix length.                     |
+| `{{ .mgmtIPv4Network }}`   | `172.20.20.0/24`            | IPv4 management network in CIDR notation.          |
+| `{{ .mgmtGatewayIPv4 }}`   | `172.20.20.1`               | IPv4 management default gateway.                   |
+| `{{ .mgmtIPv6 }}`          | `2001:db8:20::10/64`        | IPv6 management address in CIDR notation.          |
+| `{{ .mgmtIPv6Address }}`   | `2001:db8:20::10`           | IPv6 management address without prefix length.     |
+| `{{ .mgmtIPv6PrefixLen }}` | `64`                        | IPv6 management prefix length.                     |
+| `{{ .mgmtIPv6Network }}`   | `2001:db8:20::/64`          | IPv6 management network in CIDR notation.          |
+| `{{ .mgmtGatewayIPv6 }}`   | `2001:db8:20::1`            | IPv6 management default gateway.                   |
+
+In packaging and legacy host-forwarded management mode, management template
+values resolve to the QEMU user-network defaults (`10.0.0.15/24` and
+`10.0.0.2`). In transparent management runtime mode, Boxen reads the values from
+container `eth0` and the container default routes. IPv6 values can be empty when
+the container management interface has no global IPv6 address or default route,
+so profile commands that use IPv6 should guard them when needed:
+
+```yaml
+content: |
+  if [ -n "{{ .mgmtIPv6 }}" ]; then nv set interface eth0 ipv6 address {{ .mgmtIPv6 }}; fi
+```

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ The following values are available:
 | `{{ .mgmtIPv6Network }}`   | `2001:db8:20::/64`          | IPv6 management network in CIDR notation.          |
 | `{{ .mgmtIPv6Gateway }}`   | `2001:db8:20::1`            | IPv6 management default gateway.                   |
 
+`extraFiles` is a list, so index it to reference a single file by position -- for example
+`{{ index .extraFiles 0 }}` resolves to `license.lic`.
+
 In packaging and legacy host-forwarded management mode, management template
 values resolve to the QEMU user-network defaults (`10.0.0.15/24` and
 `10.0.0.2`). In transparent management runtime mode, Boxen reads the values from

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The following values are available:
 | `{{ .username }}`          | `admin`                     | Containerlab-provided username during run.         |
 | `{{ .password }}`          | `admin`                     | Containerlab-provided password during run.         |
 | `{{ .hostname }}`          | `leaf1`                     | Containerlab node hostname during run.             |
+| `{{ .mgmtDHCP }}`          | `false`                     | Whether management config should use DHCP.         |
 | `{{ .mgmtIPv4 }}`          | `172.20.20.10/24`           | IPv4 management address in CIDR notation.          |
 | `{{ .mgmtIPv4Address }}`   | `172.20.20.10`              | IPv4 management address without prefix length.     |
 | `{{ .mgmtIPv4PrefixLen }}` | `24`                        | IPv4 management prefix length.                     |
@@ -100,9 +101,23 @@ The following values are available:
 In packaging and legacy host-forwarded management mode, management template
 values resolve to the QEMU user-network defaults (`10.0.0.15/24` and
 `10.0.0.2`). In transparent management runtime mode, Boxen reads the values from
-container `eth0` and the container default routes. IPv6 values can be empty when
-the container management interface has no global IPv6 address or default route,
-so profile commands that use IPv6 should guard them when needed:
+container `eth0` and the container default routes. When `CLAB_MGMT_DHCP=true`,
+`{{ .mgmtDHCP }}` is true and address-specific management values are unavailable,
+so templates should branch into the NOS-specific DHCP syntax:
+
+```yaml
+content: |
+  {{ if .mgmtDHCP }}
+  nv set interface eth0 ipv4 address dhcp
+  {{ else }}
+  nv set interface eth0 ipv4 address {{ .mgmtIPv4 }}
+  nv set interface eth0 ipv4 gateway {{ .mgmtGatewayIPv4 }}
+  {{ end }}
+```
+
+IPv6 values can be empty when the container management interface has no global
+IPv6 address or default route, so profile commands that use IPv6 should guard
+them when needed:
 
 ```yaml
 content: |

--- a/agent/console.go
+++ b/agent/console.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	consoleHost           = "localhost"
-	consoleOpenAttempts   = 3
+	consoleOpenAttempts   = 5
 	consoleOpenRetryDelay = 3 * time.Second
 )
 

--- a/agent/instance.go
+++ b/agent/instance.go
@@ -61,6 +61,10 @@ func (a *Agent) startInstance(ctx context.Context, isPackaging bool) (*os.Proces
 			lines := strings.Split(stderrOut, "\n") //nolint: modernize
 
 			for _, line := range lines {
+				if strings.TrimSpace(line) == "" {
+					continue
+				}
+
 				if slices.ContainsFunc(
 					stderrIgnore,
 					func(sub string) bool {

--- a/agent/instance.go
+++ b/agent/instance.go
@@ -22,7 +22,7 @@ func (a *Agent) startInstance(ctx context.Context, isPackaging bool) (*os.Proces
 		return nil, err
 	}
 
-	launchArgs, err := boxenprofile.QemuArgsFromProfile(a.p, a.f, isPackaging)
+	launchArgs, err := boxenprofile.QemuArgsFromProfile(a.p, isPackaging)
 	if err != nil {
 		return nil, err
 	}

--- a/agent/instance.go
+++ b/agent/instance.go
@@ -67,7 +67,7 @@ func (a *Agent) startInstance(ctx context.Context, isPackaging bool) (*os.Proces
 						return strings.Contains(line, sub)
 					},
 				) {
-					break
+					continue
 				}
 
 				errs <- fmt.Errorf(

--- a/agent/instance.go
+++ b/agent/instance.go
@@ -46,6 +46,12 @@ func (a *Agent) startInstance(ctx context.Context, isPackaging bool) (*os.Proces
 		stderrIgnore = a.p.Packaging.StdErrIgnore
 	}
 
+	// Watch the VM's stderr for early-startup failures. On success QEMU keeps
+	// running, so we can't simply wait on the process to learn whether it came
+	// up cleanly. Instead we periodically poll the accumulated stderr buffer and
+	// treat the first non-blank line that isn't in the profile's ignore list as
+	// a fatal error, surfacing it on the errs channel. The select below waits a
+	// short window for such an error before declaring the instance healthy.
 	go func() {
 		for {
 			time.Sleep(stderrCheckInterval)

--- a/agent/logging.go
+++ b/agent/logging.go
@@ -45,13 +45,12 @@ func (l *wrappedSlogger) setLogStream(
 	ctx context.Context,
 	s boxenprotov1.BoxenServiceClient,
 ) error {
-	l.s = s
-
-	stream, err := l.s.Logger(ctx)
+	stream, err := s.Logger(ctx)
 	if err != nil {
 		return err
 	}
 
+	l.s = s
 	l.stream = stream
 
 	return nil

--- a/agent/package.go
+++ b/agent/package.go
@@ -74,7 +74,7 @@ func (a *Agent) Package(ctx context.Context, host string) error {
 		return err
 	}
 
-	a.f = boxenprofile.NewFormatters("", "", "", "", a.p)
+	a.f = boxenprofile.NewFormatters("", "", "", "", a.p, true)
 
 	errs := make(chan error, 1)
 

--- a/agent/process.go
+++ b/agent/process.go
@@ -269,8 +269,17 @@ func (a *Agent) processStepWrite(
 
 	a.l.Info("writing to console", "content", c, "formatters", formatters)
 
+	if len(formatters) > 0 {
+		c = fmt.Sprintf(c, formatters...)
+	}
+
+	c, err = a.f.RenderTemplate(c)
+	if err != nil {
+		return err
+	}
+
 	writeIterator := strings.SplitSeq(
-		fmt.Sprintf(c, formatters...),
+		c,
 		"\n",
 	)
 

--- a/agent/process.go
+++ b/agent/process.go
@@ -241,11 +241,6 @@ func (a *Agent) processStepWrite(
 ) error {
 	var c string
 
-	formatters, err := a.f.UnpackFormatters(step.Write.Formatters)
-	if err != nil {
-		return err
-	}
-
 	switch {
 	case step.Write.Content != "":
 		c = step.Write.Content
@@ -267,13 +262,9 @@ func (a *Agent) processStepWrite(
 		panic("unimplemented write type")
 	}
 
-	a.l.Info("writing to console", "content", c, "formatters", formatters)
+	a.l.Info("writing to console", "content", c)
 
-	if len(formatters) > 0 {
-		c = fmt.Sprintf(c, formatters...)
-	}
-
-	c, err = a.f.RenderTemplate(c)
+	c, err := a.f.RenderTemplate(c)
 	if err != nil {
 		return err
 	}

--- a/agent/run.go
+++ b/agent/run.go
@@ -31,6 +31,8 @@ func (a *Agent) Run(
 		return err
 	}
 
+	a.f = boxenprofile.NewFormatters(username, password, hostname, connectionMode, a.p, false)
+
 	defer func() {
 		if a.stdoutF == nil {
 			return
@@ -41,7 +43,7 @@ func (a *Agent) Run(
 
 	errs := make(chan error, 1)
 
-	go a.startRun(ctx, errs, username, password, hostname, connectionMode)
+	go a.startRun(ctx, errs)
 
 	select {
 	// here we just wait for the error or done, because we block on the context in the run
@@ -57,22 +59,13 @@ func (a *Agent) Run(
 	}
 }
 
-func (a *Agent) startRun(
-	ctx context.Context,
-	errs chan error,
-	username,
-	password,
-	hostname,
-	connectionMode string,
-) {
+func (a *Agent) startRun(ctx context.Context, errs chan error) {
 	err := a.runClabNICProvisionDelay(ctx)
 	if err != nil {
 		errs <- err
 
 		return
 	}
-
-	a.f = boxenprofile.NewFormatters(username, password, hostname, connectionMode, a.p, false)
 
 	err = a.runClabStartDelay(ctx)
 	if err != nil {

--- a/agent/run.go
+++ b/agent/run.go
@@ -175,13 +175,13 @@ func (a *Agent) runPreCommands(ctx context.Context) error {
 }
 
 func (a *Agent) runClabNICProvisionDelay(ctx context.Context) error {
-	clabIntfCount := boxenutil.GetEnvIntOrDefault("CLAB_INTFS", 0)
+	clabIntfCount := boxenutil.GetEnvIntOrDefault(boxenconstants.EnvClabIntfs, 0)
 
 	if clabIntfCount == 0 {
 		return nil
 	}
 
-	intfPrefix := boxenutil.GetEnvStrOrDefault(boxenconstants.EnvClabIntfPrefix, "eth")
+	intfPrefix := boxenutil.ClabIntfPrefix()
 
 	a.l.Info("waiting for clab nics to be priviosined", "count", clabIntfCount)
 

--- a/agent/run.go
+++ b/agent/run.go
@@ -31,8 +31,6 @@ func (a *Agent) Run(
 		return err
 	}
 
-	a.f = boxenprofile.NewFormatters(username, password, hostname, connectionMode, a.p)
-
 	defer func() {
 		if a.stdoutF == nil {
 			return
@@ -43,7 +41,7 @@ func (a *Agent) Run(
 
 	errs := make(chan error, 1)
 
-	go a.startRun(ctx, errs)
+	go a.startRun(ctx, errs, username, password, hostname, connectionMode)
 
 	select {
 	// here we just wait for the error or done, because we block on the context in the run
@@ -59,13 +57,22 @@ func (a *Agent) Run(
 	}
 }
 
-func (a *Agent) startRun(ctx context.Context, errs chan error) {
+func (a *Agent) startRun(
+	ctx context.Context,
+	errs chan error,
+	username,
+	password,
+	hostname,
+	connectionMode string,
+) {
 	err := a.runClabNICProvisionDelay(ctx)
 	if err != nil {
 		errs <- err
 
 		return
 	}
+
+	a.f = boxenprofile.NewFormatters(username, password, hostname, connectionMode, a.p, false)
 
 	err = a.runClabStartDelay(ctx)
 	if err != nil {

--- a/assets/profiles/arista_veos.yaml
+++ b/assets/profiles/arista_veos.yaml
@@ -220,15 +220,10 @@ run:
           configure terminal
     - type: write
       write:
-        content: username %s secret 0 %s role network-admin
-        formatters:
-          - username
-          - password
+        content: username {{ .username }} secret 0 {{ .password }} role network-admin
     - type: write
       write:
-        content: hostname %s
-        formatters:
-          - hostname
+        content: hostname {{ .hostname }}
     # load any user provided startup config
     - type: write
       write:

--- a/assets/profiles/cisco_csr1000v.yaml
+++ b/assets/profiles/cisco_csr1000v.yaml
@@ -151,15 +151,10 @@ run:
           configure terminal
     - type: write
       write:
-        content: username %s privilege 15 password %s
-        formatters:
-          - username
-          - password
+        content: username {{ .username }} privilege 15 password {{ .password }}
     - type: write
       write:
-        content: hostname %s
-        formatters:
-          - hostname
+        content: hostname {{ .hostname }}
     # load any user provided startup config
     - type: write
       write:

--- a/assets/profiles/cisco_n9kv.yaml
+++ b/assets/profiles/cisco_n9kv.yaml
@@ -117,10 +117,8 @@ packaging:
           vrf context management
           ip route 0.0.0.0/0 10.0.0.2
           exit
-          boot nxos bootflash:///nxos.%s.bin
+          boot nxos bootflash:///nxos.{{ .version }}.bin
           end
-        formatters:
-          - version
     - type: write
       write:
         content:
@@ -174,15 +172,10 @@ run:
           configure terminal
     - type: write
       write:
-        content: username %s password 0 %s role network-admin
-        formatters:
-          - username
-          - password
+        content: username {{ .username }} password 0 {{ .password }} role network-admin
     - type: write
       write:
-        content: hostname %s
-        formatters:
-          - hostname
+        content: hostname {{ .hostname }}
     # load any user provided startup config
     - type: write
       write:

--- a/assets/profiles/cisco_xrv9k.yaml
+++ b/assets/profiles/cisco_xrv9k.yaml
@@ -211,15 +211,10 @@ run:
           configure terminal
     - type: write
       write:
-        content: username %s secret 0 %s role network-admin
-        formatters:
-          - username
-          - password
+        content: username {{ .username }} secret 0 {{ .password }} role network-admin
     - type: write
       write:
-        content: hostname %s
-        formatters:
-          - hostname
+        content: hostname {{ .hostname }}
     # load any user provided startup config
     - type: write
       write:

--- a/boxen/build.go
+++ b/boxen/build.go
@@ -136,13 +136,17 @@ func (b *Boxen) Build(
 
 	fmt.Fprintf(&imageID, "boxen-%s:%s", b.p.Name, imageTag)
 
+	natPorts := b.p.VirtualMachine.NatPorts
+	if b.p.VirtualMachine.ManagementPassthrough {
+		natPorts = nil
+	}
+
 	err = b.c.Commit(
 		ctx,
 		b.l,
 		containerID,
 		imageID.String(),
-		b.p.VirtualMachine.NatPorts,
-		!b.p.VirtualMachine.ManagementPassthrough,
+		natPorts,
 	)
 	if err != nil {
 		return err

--- a/boxen/build.go
+++ b/boxen/build.go
@@ -142,6 +142,7 @@ func (b *Boxen) Build(
 		containerID,
 		imageID.String(),
 		b.p.VirtualMachine.NatPorts,
+		!b.p.VirtualMachine.ManagementPassthrough,
 	)
 	if err != nil {
 		return err

--- a/build/agent.Dockerfile
+++ b/build/agent.Dockerfile
@@ -51,7 +51,8 @@ RUN apt-get update && \
 WORKDIR /boxen
 
 COPY build/tc-tap-ifup /etc/
-RUN chmod 0777 /etc/tc-tap-ifup
+COPY build/tc-tap-mgmt-ifup /etc/
+RUN chmod 0777 /etc/tc-tap-ifup /etc/tc-tap-mgmt-ifup
 
 COPY build/scrapligo_definition.yaml .scrapligo_definition.yaml
 

--- a/build/tc-tap-mgmt-ifup
+++ b/build/tc-tap-mgmt-ifup
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+TAP_IF=$1
+MGMT_IF=${CLAB_MGMT_INTF:-eth0}
+
+ip link set "$TAP_IF" up
+ip link set "$TAP_IF" mtu 65000
+
+# Avoid periodic traffic from the container itself leaking into the VM mgmt path.
+ip -6 addr flush "$TAP_IF" || true
+
+tc qdisc replace dev "$MGMT_IF" clsact
+
+# Keep the QEMU serial console reachable on the container while redirecting mgmt traffic.
+tc filter replace dev "$MGMT_IF" ingress prio 1 protocol ip flower ip_proto tcp dst_port 5001-5008 action pass
+
+# Mirror ARP so the container network stack can still resolve neighbors when needed.
+tc filter replace dev "$MGMT_IF" ingress prio 2 protocol arp flower action mirred egress mirror dev "$TAP_IF"
+
+# Redirect normal management traffic to the VM management tap.
+tc filter replace dev "$MGMT_IF" ingress prio 3 flower action mirred egress redirect dev "$TAP_IF"
+
+tc qdisc replace dev "$TAP_IF" clsact
+tc filter replace dev "$TAP_IF" ingress flower action mirred egress redirect dev "$MGMT_IF"
+
+if [[ -n "${CLAB_MGMT_MAC:-}" ]]; then
+  ip link set dev "$MGMT_IF" address "$CLAB_MGMT_MAC"
+fi

--- a/constants/containerlab.go
+++ b/constants/containerlab.go
@@ -3,6 +3,7 @@ package constants
 const (
 	EnvClabMgmtPassthrough = "CLAB_MGMT_PASSTHROUGH" //nolint: gosec
 	EnvClabMgmtDHCP        = "CLAB_MGMT_DHCP"
+	EnvClabMgmtMAC         = "CLAB_MGMT_MAC"
 	EnvClabIntfPrefix      = "CLAB_INTF_PREFIX"
 	EnvClabIntfs           = "CLAB_INTFS"
 	EnvClabBootDelay       = "BOOT_DELAY"

--- a/container/container.go
+++ b/container/container.go
@@ -37,6 +37,7 @@ type Runtime interface {
 		containerID,
 		imageID string,
 		natPorts []boxenprofile.NatPort,
+		exposeNatPorts bool,
 	) error
 	Rm(
 		ctx context.Context,

--- a/container/container.go
+++ b/container/container.go
@@ -37,7 +37,6 @@ type Runtime interface {
 		containerID,
 		imageID string,
 		natPorts []boxenprofile.NatPort,
-		exposeNatPorts bool,
 	) error
 	Rm(
 		ctx context.Context,

--- a/container/docker/commit.go
+++ b/container/docker/commit.go
@@ -17,6 +17,7 @@ func (r *Runtime) Commit(
 	containerID,
 	imageID string,
 	natPorts []boxenprofile.NatPort,
+	exposeNatPorts bool,
 ) error {
 	args := []string{ //nolint: prealloc
 		"commit",
@@ -24,16 +25,18 @@ func (r *Runtime) Commit(
 		`ENTRYPOINT ["/boxen/boxen", "run"]`,
 	}
 
-	for idx := range natPorts {
-		args = append(
-			args,
-			"--change",
-			fmt.Sprintf(
-				`EXPOSE %d/%s`,
-				natPorts[idx].LocalPort,
-				strings.ToUpper(string(natPorts[idx].Type)),
-			),
-		)
+	if exposeNatPorts {
+		for idx := range natPorts {
+			args = append(
+				args,
+				"--change",
+				fmt.Sprintf(
+					`EXPOSE %d/%s`,
+					natPorts[idx].LocalPort,
+					strings.ToUpper(string(natPorts[idx].Type)),
+				),
+			)
+		}
 	}
 
 	args = append(

--- a/container/docker/commit.go
+++ b/container/docker/commit.go
@@ -17,7 +17,6 @@ func (r *Runtime) Commit(
 	containerID,
 	imageID string,
 	natPorts []boxenprofile.NatPort,
-	exposeNatPorts bool,
 ) error {
 	args := []string{ //nolint: prealloc
 		"commit",
@@ -25,18 +24,16 @@ func (r *Runtime) Commit(
 		`ENTRYPOINT ["/boxen/boxen", "run"]`,
 	}
 
-	if exposeNatPorts {
-		for idx := range natPorts {
-			args = append(
-				args,
-				"--change",
-				fmt.Sprintf(
-					`EXPOSE %d/%s`,
-					natPorts[idx].LocalPort,
-					strings.ToUpper(string(natPorts[idx].Type)),
-				),
-			)
-		}
+	for idx := range natPorts {
+		args = append(
+			args,
+			"--change",
+			fmt.Sprintf(
+				`EXPOSE %d/%s`,
+				natPorts[idx].LocalPort,
+				strings.ToUpper(string(natPorts[idx].Type)),
+			),
+		)
 	}
 
 	args = append(

--- a/profile/common.go
+++ b/profile/common.go
@@ -93,7 +93,12 @@ type StepReadUntil struct {
 
 // StepWrite holds things we want to write to the terminal during a package/run.
 type StepWrite struct {
-	// write this content.
+	// write this content. Content is rendered as a Go template, so it may reference named values
+	// such as {{ .hostname }}, {{ .username }}, {{ .password }}, {{ .version }}, {{ .disk }},
+	// {{ index .extraFiles 0 }}, or management values like {{ .mgmtIPv4Address }}. The
+	// "containerlab" values (username/password/hostname) are only populated during the run process
+	// since they are only passed when boxen is invoked from containerlab; disk, extraFiles, and
+	// version are available for both packaging and run. See the README for the full list of values.
 	Content string `yaml:"content"`
 	// write content line-by-line from the file set here.
 	ContentFromFile string `yaml:"contentFromFile"`
@@ -101,21 +106,6 @@ type StepWrite struct {
 	// (/config/startup-config.cfg), this should only be used in the "run" stage because the startup
 	// config won't be present in the packaging stage.
 	ContentFromStartupConfig bool `yaml:"contentFromStartupConfig"`
-
-	// Formatters holds the formatters you want to apply to the content -- note that the
-	// "containerlab" formatters (username/password/hostname) are only available during the run
-	// process since of course they are only passed when boxen is invoked from containerlab.
-	// The disk, extraFiles, and version formatters, however, are available for both the package
-	// and run processes since those are boxen known. Content can also use named Go template
-	// variables, for example {{ .hostname }} or {{ .mgmtIPv4Address }}.
-	// Allowed "formatters":
-	// 	- username
-	// 	- password
-	// 	- hostname
-	// 	- extraFile[n] <- where n is the index (zero indexed) of the extra file you want to use
-	// 	- disk
-	//  - version (as matched via the version pattern at profile root)
-	Formatters []string `yaml:"formatters"`
 
 	// if marked hidden we wont read the inputs we send off the channel, use this for
 	// passwords and the like

--- a/profile/common.go
+++ b/profile/common.go
@@ -106,7 +106,8 @@ type StepWrite struct {
 	// "containerlab" formatters (username/password/hostname) are only available during the run
 	// process since of course they are only passed when boxen is invoked from containerlab.
 	// The disk, extraFiles, and version formatters, however, are available for both the package
-	// and run processes since those are boxen known.
+	// and run processes since those are boxen known. Content can also use named Go template
+	// variables, for example {{ .hostname }} or {{ .mgmtIPv4Address }}.
 	// Allowed "formatters":
 	// 	- username
 	// 	- password

--- a/profile/formatters.go
+++ b/profile/formatters.go
@@ -311,7 +311,7 @@ func (f *Formatters) getManagementFormatters() (*managementFormatters, error) {
 		f.management = defaultManagementFormatters()
 	case !f.p.VirtualMachine.IsManagementPassthroughEnabled():
 		f.management = defaultManagementFormatters()
-	case envBoolTrue(boxenconstants.EnvClabMgmtDHCP):
+	case boxenutil.EnvBoolTrue(boxenconstants.EnvClabMgmtDHCP):
 		f.management = dhcpManagementFormatters()
 	default:
 		management, err := runtimeManagementFormatters(context.Background())
@@ -460,10 +460,4 @@ func (m *managementFormatters) applyCIDR(cidr, family string) error {
 	}
 
 	return nil
-}
-
-func envBoolTrue(k string) bool {
-	v := boxenutil.GetEnvStrOrDefault(k, "")
-
-	return strings.ToLower(v) == "true"
 }

--- a/profile/formatters.go
+++ b/profile/formatters.go
@@ -40,6 +40,7 @@ type Formatters struct {
 }
 
 type managementFormatters struct {
+	dhcp          bool
 	ipv4          string
 	ipv4Address   string
 	ipv4PrefixLen string
@@ -230,6 +231,11 @@ func (f *Formatters) TemplateData(includeManagement bool) (map[string]any, error
 		return nil, err
 	}
 
+	data["mgmtDHCP"] = management.dhcp
+	if management.dhcp {
+		return data, nil
+	}
+
 	data["mgmtIPv4"] = management.ipv4
 	data["mgmtIPv4Address"] = management.ipv4Address
 	data["mgmtIPv4PrefixLen"] = management.ipv4PrefixLen
@@ -275,6 +281,15 @@ func (f *Formatters) managementFormatter(formatter string) (string, error) {
 		v = management.ipv6Gateway
 	default:
 		return "", fmt.Errorf("%w: invalid formatter %q", boxenerrors.ErrBoxen, formatter)
+	}
+
+	if management.dhcp {
+		return "", fmt.Errorf(
+			"%w: formatter %q unavailable when %s=true; use mgmtDHCP in a template",
+			boxenerrors.ErrBoxen,
+			formatter,
+			boxenconstants.EnvClabMgmtDHCP,
+		)
 	}
 
 	if v == "" && !strings.Contains(formatter, "IPv6") {
@@ -324,16 +339,7 @@ func defaultManagementFormatters() *managementFormatters {
 
 func dhcpManagementFormatters() *managementFormatters {
 	return &managementFormatters{
-		ipv4:          "dhcp",
-		ipv4Address:   "dhcp",
-		ipv4PrefixLen: "dhcp",
-		ipv4Network:   "dhcp",
-		ipv4Gateway:   "dhcp",
-		ipv6:          "dhcp",
-		ipv6Address:   "dhcp",
-		ipv6PrefixLen: "dhcp",
-		ipv6Network:   "dhcp",
-		ipv6Gateway:   "dhcp",
+		dhcp: true,
 	}
 }
 

--- a/profile/formatters.go
+++ b/profile/formatters.go
@@ -13,7 +13,6 @@ import (
 	"text/template"
 
 	boxenconstants "github.com/carlmontanari/boxen/constants"
-	boxenerrors "github.com/carlmontanari/boxen/errors"
 	boxenutil "github.com/carlmontanari/boxen/util"
 )
 
@@ -24,22 +23,7 @@ const (
 	defaultMgmtIPv6Gateway = "2001:db8::1"
 )
 
-// optionalMgmtFormatters is the single source of truth for which management
-// formatter/template keys may legitimately resolve to an empty value. IPv6
-// management connectivity is not guaranteed in every environment, so IPv6 keys
-// are optional while IPv4 keys are always expected. The positional formatter
-// path errors when a required key is empty; the template path keeps every key
-// present-but-empty so profiles can guard them with {{ if .mgmtIPv6 }} or a
-// shell `[ -n "..." ]` check.
-var optionalMgmtFormatters = map[string]bool{
-	"mgmtIPv6":          true,
-	"mgmtIPv6Address":   true,
-	"mgmtIPv6PrefixLen": true,
-	"mgmtIPv6Network":   true,
-	"mgmtIPv6Gateway":   true,
-}
-
-// Formatters holds all the valid "formatter" options for string interpolation in profile content.
+// Formatters holds the values available for Go template interpolation in profile content.
 type Formatters struct {
 	disk           string
 	version        string
@@ -68,9 +52,8 @@ type managementFormatters struct {
 	ipv6Gateway   string
 }
 
-// toMap returns the management values keyed by their formatter/template names. It
-// is the single source of truth shared by the positional formatter path
-// (managementFormatter) and the named template path (TemplateData).
+// toMap returns the management values keyed by their template names. It is the single
+// source of truth for the values exposed to write content templates via TemplateData.
 func (m *managementFormatters) toMap() map[string]string {
 	return map[string]string{
 		"mgmtIPv4":          m.ipv4,
@@ -149,77 +132,6 @@ func NewFormatters(
 	}
 }
 
-// UnpackFormatters accepts the users inputs, and returns a list of formatters to use with Sprintf.
-func (f *Formatters) UnpackFormatters(inputs []string) ([]any, error) {
-	// simpleFormatters are the "required, non-empty" scalar formatters; they all
-	// share the same "unset" error handling so they live in a single table.
-	simpleFormatters := map[string]string{
-		"disk":     f.disk,
-		"version":  f.version,
-		"username": f.username,
-		"password": f.password,
-		"hostname": f.hostname,
-	}
-
-	var formatters []any
-
-	for _, formatter := range inputs {
-		if v, ok := simpleFormatters[formatter]; ok {
-			if v == "" {
-				return nil, fmt.Errorf(
-					"%w: %s unset but %s formatter requested",
-					boxenerrors.ErrBoxen, formatter, formatter,
-				)
-			}
-
-			formatters = append(formatters, v)
-
-			continue
-		}
-
-		switch {
-		case strings.HasPrefix(formatter, "extraFile"):
-			v, err := f.extraFileFormatter(formatter)
-			if err != nil {
-				return nil, err
-			}
-
-			formatters = append(formatters, v)
-		case strings.HasPrefix(formatter, "mgmt"):
-			v, err := f.managementFormatter(formatter)
-			if err != nil {
-				return nil, err
-			}
-
-			formatters = append(formatters, v)
-		default:
-			return nil, fmt.Errorf("%w: invalid formatter %q", boxenerrors.ErrBoxen, formatter)
-		}
-	}
-
-	return formatters, nil
-}
-
-func (f *Formatters) extraFileFormatter(formatter string) (string, error) {
-	idxStr := strings.TrimSuffix(strings.TrimPrefix(formatter, "extraFile["), "]")
-
-	idx, err := strconv.Atoi(idxStr)
-	if err != nil {
-		return "", err
-	}
-
-	if idx < 0 || idx >= len(f.extraFiles) {
-		return "", fmt.Errorf(
-			"%w: extraFile index %d out of range (have %d extra files)",
-			boxenerrors.ErrBoxen,
-			idx,
-			len(f.extraFiles),
-		)
-	}
-
-	return f.extraFiles[idx], nil
-}
-
 // RenderTemplate renders write content with named Go template values.
 func (f *Formatters) RenderTemplate(content string) (string, error) {
 	if !strings.Contains(content, "{{") {
@@ -273,33 +185,6 @@ func (f *Formatters) TemplateData() (map[string]any, error) {
 	}
 
 	return data, nil
-}
-
-func (f *Formatters) managementFormatter(formatter string) (string, error) {
-	management, err := f.getManagementFormatters()
-	if err != nil {
-		return "", err
-	}
-
-	v, ok := management.toMap()[formatter]
-	if !ok {
-		return "", fmt.Errorf("%w: invalid formatter %q", boxenerrors.ErrBoxen, formatter)
-	}
-
-	if management.dhcp {
-		return "", fmt.Errorf(
-			"%w: formatter %q unavailable when %s=true; use mgmtDHCP in a template",
-			boxenerrors.ErrBoxen,
-			formatter,
-			boxenconstants.EnvClabMgmtDHCP,
-		)
-	}
-
-	if v == "" && !optionalMgmtFormatters[formatter] {
-		return "", fmt.Errorf("%w: formatter %q unset", boxenerrors.ErrBoxen, formatter)
-	}
-
-	return v, nil
 }
 
 func (f *Formatters) getManagementFormatters() (*managementFormatters, error) {

--- a/profile/formatters.go
+++ b/profile/formatters.go
@@ -24,6 +24,21 @@ const (
 	defaultMgmtIPv6Gateway = "2001:db8::1"
 )
 
+// optionalMgmtFormatters is the single source of truth for which management
+// formatter/template keys may legitimately resolve to an empty value. IPv6
+// management connectivity is not guaranteed in every environment, so IPv6 keys
+// are optional while IPv4 keys are always expected. The positional formatter
+// path errors when a required key is empty; the template path keeps every key
+// present-but-empty so profiles can guard them with {{ if .mgmtIPv6 }} or a
+// shell `[ -n "..." ]` check.
+var optionalMgmtFormatters = map[string]bool{
+	"mgmtIPv6":          true,
+	"mgmtIPv6Address":   true,
+	"mgmtIPv6PrefixLen": true,
+	"mgmtIPv6Network":   true,
+	"mgmtGatewayIPv6":   true,
+}
+
 // Formatters holds all the valid "formatter" options for string interpolation in profile content.
 type Formatters struct {
 	disk           string
@@ -71,8 +86,10 @@ var (
 		return exec.CommandContext(ctx, "ip", "--json", "address", "show", "dev", intf).Output() //nolint:gosec
 	}
 
-	ipRouteShowDefaultCommand = func(ctx context.Context, family string) ([]byte, error) {
-		return exec.CommandContext(ctx, "ip", "--json", family, "route", "show", "default").Output() //nolint:gosec
+	ipRouteShowDefaultCommand = func(ctx context.Context, family, intf string) ([]byte, error) {
+		return exec.CommandContext(
+			ctx, "ip", "--json", family, "route", "show", "default", "dev", intf,
+		).Output() //nolint:gosec
 	}
 )
 
@@ -137,11 +154,20 @@ func (f *Formatters) UnpackFormatters(inputs []string) ([]any, error) {
 
 			formatters = append(formatters, f.version)
 		case strings.HasPrefix(formatter, "extraFile"):
-			idxStr := strings.TrimRight(strings.TrimLeft("extraFile[", formatter), "]")
+			idxStr := strings.TrimSuffix(strings.TrimPrefix(formatter, "extraFile["), "]")
 
 			idx, err := strconv.Atoi(idxStr)
 			if err != nil {
 				return nil, err
+			}
+
+			if idx < 0 || idx >= len(f.extraFiles) {
+				return nil, fmt.Errorf(
+					"%w: extraFile index %d out of range (have %d extra files)",
+					boxenerrors.ErrBoxen,
+					idx,
+					len(f.extraFiles),
+				)
 			}
 
 			formatters = append(formatters, f.extraFiles[idx])
@@ -288,7 +314,7 @@ func (f *Formatters) managementFormatter(formatter string) (string, error) {
 		)
 	}
 
-	if v == "" && !strings.Contains(formatter, "IPv6") {
+	if v == "" && !optionalMgmtFormatters[formatter] {
 		return "", fmt.Errorf("%w: formatter %q unset", boxenerrors.ErrBoxen, formatter)
 	}
 
@@ -343,14 +369,15 @@ func dhcpManagementFormatters() *managementFormatters {
 
 func runtimeManagementFormatters(ctx context.Context) (*managementFormatters, error) {
 	intfPrefix := boxenutil.GetEnvStrOrDefault(boxenconstants.EnvClabIntfPrefix, "eth")
+	mgmtIntf := fmt.Sprintf("%s0", intfPrefix)
 	management := &managementFormatters{}
 
-	err := management.setRuntimeAddresses(ctx, fmt.Sprintf("%s0", intfPrefix))
+	err := management.setRuntimeAddresses(ctx, mgmtIntf)
 	if err != nil {
 		return nil, err
 	}
 
-	err = management.setRuntimeGateways(ctx)
+	err = management.setRuntimeGateways(ctx, mgmtIntf)
 	if err != nil {
 		return nil, err
 	}
@@ -400,14 +427,15 @@ func (m *managementFormatters) setRuntimeAddresses(ctx context.Context, intf str
 }
 
 // setRuntimeGateways sets the runtime default gateways for the managementFormatters struct.
-// It reads the default routes for IPv4 and IPv6 and sets the appropriate fields in the managementFormatters struct.
-func (m *managementFormatters) setRuntimeGateways(ctx context.Context) error {
-	ipv4Gateway, err := runtimeDefaultGateway(ctx, "-4")
+// It reads the default routes for IPv4 and IPv6 on the management interface and sets the
+// appropriate fields in the managementFormatters struct.
+func (m *managementFormatters) setRuntimeGateways(ctx context.Context, intf string) error {
+	ipv4Gateway, err := runtimeDefaultGateway(ctx, "-4", intf)
 	if err != nil {
 		return err
 	}
 
-	ipv6Gateway, err := runtimeDefaultGateway(ctx, "-6")
+	ipv6Gateway, err := runtimeDefaultGateway(ctx, "-6", intf)
 	if err != nil {
 		return err
 	}
@@ -418,10 +446,12 @@ func (m *managementFormatters) setRuntimeGateways(ctx context.Context) error {
 	return nil
 }
 
-// runtimeDefaultGateway returns the default gateway for the given family.
-// It reads the default route for the given family and returns the gateway IP address.
-func runtimeDefaultGateway(ctx context.Context, family string) (string, error) {
-	b, err := ipRouteShowDefaultCommand(ctx, family)
+// runtimeDefaultGateway returns the default gateway for the given family on the given interface.
+// Scoping the lookup to the management interface avoids picking up a default route that egresses a
+// different interface when the container has more than one. It returns the gateway IP address, or
+// an empty string when no default route exists on that interface for the family.
+func runtimeDefaultGateway(ctx context.Context, family, intf string) (string, error) {
+	b, err := ipRouteShowDefaultCommand(ctx, family, intf)
 	if err != nil {
 		return "", err
 	}

--- a/profile/formatters.go
+++ b/profile/formatters.go
@@ -36,7 +36,7 @@ var optionalMgmtFormatters = map[string]bool{
 	"mgmtIPv6Address":   true,
 	"mgmtIPv6PrefixLen": true,
 	"mgmtIPv6Network":   true,
-	"mgmtGatewayIPv6":   true,
+	"mgmtIPv6Gateway":   true,
 }
 
 // Formatters holds all the valid "formatter" options for string interpolation in profile content.
@@ -66,6 +66,24 @@ type managementFormatters struct {
 	ipv6PrefixLen string
 	ipv6Network   string
 	ipv6Gateway   string
+}
+
+// toMap returns the management values keyed by their formatter/template names. It
+// is the single source of truth shared by the positional formatter path
+// (managementFormatter) and the named template path (TemplateData).
+func (m *managementFormatters) toMap() map[string]string {
+	return map[string]string{
+		"mgmtIPv4":          m.ipv4,
+		"mgmtIPv4Address":   m.ipv4Address,
+		"mgmtIPv4PrefixLen": m.ipv4PrefixLen,
+		"mgmtIPv4Network":   m.ipv4Network,
+		"mgmtIPv4Gateway":   m.ipv4Gateway,
+		"mgmtIPv6":          m.ipv6,
+		"mgmtIPv6Address":   m.ipv6Address,
+		"mgmtIPv6PrefixLen": m.ipv6PrefixLen,
+		"mgmtIPv6Network":   m.ipv6Network,
+		"mgmtIPv6Gateway":   m.ipv6Gateway,
+	}
 }
 
 type ipAddressShowOutput []struct {
@@ -133,68 +151,40 @@ func NewFormatters(
 
 // UnpackFormatters accepts the users inputs, and returns a list of formatters to use with Sprintf.
 func (f *Formatters) UnpackFormatters(inputs []string) ([]any, error) {
+	// simpleFormatters are the "required, non-empty" scalar formatters; they all
+	// share the same "unset" error handling so they live in a single table.
+	simpleFormatters := map[string]string{
+		"disk":     f.disk,
+		"version":  f.version,
+		"username": f.username,
+		"password": f.password,
+		"hostname": f.hostname,
+	}
+
 	var formatters []any
 
 	for _, formatter := range inputs {
+		if v, ok := simpleFormatters[formatter]; ok {
+			if v == "" {
+				return nil, fmt.Errorf(
+					"%w: %s unset but %s formatter requested",
+					boxenerrors.ErrBoxen, formatter, formatter,
+				)
+			}
+
+			formatters = append(formatters, v)
+
+			continue
+		}
+
 		switch {
-		case formatter == "disk":
-			if f.disk == "" {
-				return nil, fmt.Errorf(
-					"%w: disk unset but disk formatter requested", boxenerrors.ErrBoxen,
-				)
-			}
-
-			formatters = append(formatters, f.disk)
-		case formatter == "version":
-			if f.version == "" {
-				return nil, fmt.Errorf(
-					"%w: version unset but version formatter requested", boxenerrors.ErrBoxen,
-				)
-			}
-
-			formatters = append(formatters, f.version)
 		case strings.HasPrefix(formatter, "extraFile"):
-			idxStr := strings.TrimSuffix(strings.TrimPrefix(formatter, "extraFile["), "]")
-
-			idx, err := strconv.Atoi(idxStr)
+			v, err := f.extraFileFormatter(formatter)
 			if err != nil {
 				return nil, err
 			}
 
-			if idx < 0 || idx >= len(f.extraFiles) {
-				return nil, fmt.Errorf(
-					"%w: extraFile index %d out of range (have %d extra files)",
-					boxenerrors.ErrBoxen,
-					idx,
-					len(f.extraFiles),
-				)
-			}
-
-			formatters = append(formatters, f.extraFiles[idx])
-		case formatter == "username":
-			if f.username == "" {
-				return nil, fmt.Errorf(
-					"%w: username unset but username formatter requested", boxenerrors.ErrBoxen,
-				)
-			}
-
-			formatters = append(formatters, f.username)
-		case formatter == "password":
-			if f.password == "" {
-				return nil, fmt.Errorf(
-					"%w: password unset but password formatter requested", boxenerrors.ErrBoxen,
-				)
-			}
-
-			formatters = append(formatters, f.password)
-		case formatter == "hostname":
-			if f.hostname == "" {
-				return nil, fmt.Errorf(
-					"%w: hostname unset but hostname formatter requested", boxenerrors.ErrBoxen,
-				)
-			}
-
-			formatters = append(formatters, f.hostname)
+			formatters = append(formatters, v)
 		case strings.HasPrefix(formatter, "mgmt"):
 			v, err := f.managementFormatter(formatter)
 			if err != nil {
@@ -208,6 +198,26 @@ func (f *Formatters) UnpackFormatters(inputs []string) ([]any, error) {
 	}
 
 	return formatters, nil
+}
+
+func (f *Formatters) extraFileFormatter(formatter string) (string, error) {
+	idxStr := strings.TrimSuffix(strings.TrimPrefix(formatter, "extraFile["), "]")
+
+	idx, err := strconv.Atoi(idxStr)
+	if err != nil {
+		return "", err
+	}
+
+	if idx < 0 || idx >= len(f.extraFiles) {
+		return "", fmt.Errorf(
+			"%w: extraFile index %d out of range (have %d extra files)",
+			boxenerrors.ErrBoxen,
+			idx,
+			len(f.extraFiles),
+		)
+	}
+
+	return f.extraFiles[idx], nil
 }
 
 // RenderTemplate renders write content with named Go template values.
@@ -258,16 +268,9 @@ func (f *Formatters) TemplateData() (map[string]any, error) {
 		return data, nil
 	}
 
-	data["mgmtIPv4"] = management.ipv4
-	data["mgmtIPv4Address"] = management.ipv4Address
-	data["mgmtIPv4PrefixLen"] = management.ipv4PrefixLen
-	data["mgmtIPv4Network"] = management.ipv4Network
-	data["mgmtGatewayIPv4"] = management.ipv4Gateway
-	data["mgmtIPv6"] = management.ipv6
-	data["mgmtIPv6Address"] = management.ipv6Address
-	data["mgmtIPv6PrefixLen"] = management.ipv6PrefixLen
-	data["mgmtIPv6Network"] = management.ipv6Network
-	data["mgmtGatewayIPv6"] = management.ipv6Gateway
+	for k, v := range management.toMap() {
+		data[k] = v
+	}
 
 	return data, nil
 }
@@ -278,30 +281,8 @@ func (f *Formatters) managementFormatter(formatter string) (string, error) {
 		return "", err
 	}
 
-	var v string
-
-	switch formatter {
-	case "mgmtIPv4":
-		v = management.ipv4
-	case "mgmtIPv4Address":
-		v = management.ipv4Address
-	case "mgmtIPv4PrefixLen":
-		v = management.ipv4PrefixLen
-	case "mgmtIPv4Network":
-		v = management.ipv4Network
-	case "mgmtGatewayIPv4":
-		v = management.ipv4Gateway
-	case "mgmtIPv6":
-		v = management.ipv6
-	case "mgmtIPv6Address":
-		v = management.ipv6Address
-	case "mgmtIPv6PrefixLen":
-		v = management.ipv6PrefixLen
-	case "mgmtIPv6Network":
-		v = management.ipv6Network
-	case "mgmtGatewayIPv6":
-		v = management.ipv6Gateway
-	default:
+	v, ok := management.toMap()[formatter]
+	if !ok {
 		return "", fmt.Errorf("%w: invalid formatter %q", boxenerrors.ErrBoxen, formatter)
 	}
 
@@ -355,8 +336,8 @@ func defaultManagementFormatters() *managementFormatters {
 		ipv6Gateway: defaultMgmtIPv6Gateway,
 	}
 
-	_ = management.applyCIDR(defaultMgmtIPv4, "ipv4")
-	_ = management.applyCIDR(defaultMgmtIPv6, "ipv6")
+	_ = management.applyIPv4CIDR(defaultMgmtIPv4)
+	_ = management.applyIPv6CIDR(defaultMgmtIPv6)
 
 	return management
 }
@@ -368,8 +349,7 @@ func dhcpManagementFormatters() *managementFormatters {
 }
 
 func runtimeManagementFormatters(ctx context.Context) (*managementFormatters, error) {
-	intfPrefix := boxenutil.GetEnvStrOrDefault(boxenconstants.EnvClabIntfPrefix, "eth")
-	mgmtIntf := fmt.Sprintf("%s0", intfPrefix)
+	mgmtIntf := boxenutil.ClabMgmtIntfName()
 	management := &managementFormatters{}
 
 	err := management.setRuntimeAddresses(ctx, mgmtIntf)
@@ -410,9 +390,9 @@ func (m *managementFormatters) setRuntimeAddresses(ctx context.Context, intf str
 
 			switch addrInfo.Family {
 			case "inet":
-				err = m.applyCIDR(cidr, "ipv4")
+				err = m.applyIPv4CIDR(cidr)
 			case "inet6":
-				err = m.applyCIDR(cidr, "ipv6")
+				err = m.applyIPv6CIDR(cidr)
 			default:
 				continue
 			}
@@ -470,30 +450,42 @@ func runtimeDefaultGateway(ctx context.Context, family, intf string) (string, er
 	return o[0].Gateway, nil
 }
 
-// applyCIDR applies the CIDR to the managementFormatters struct for the given family.
-// It parses the CIDR, extracts the address, network, and prefix length, and sets the appropriate fields in the managementFormatters struct.
-func (m *managementFormatters) applyCIDR(cidr, family string) error {
+// parseCIDR parses a CIDR string into its address, network, and prefix-length parts.
+func parseCIDR(cidr string) (address, network, prefixLen string, err error) {
 	prefix, err := netip.ParsePrefix(cidr)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	return prefix.Addr().String(), prefix.Masked().String(), strconv.Itoa(prefix.Bits()), nil
+}
+
+// applyIPv4CIDR sets the IPv4 address, network, and prefix-length fields from the given CIDR.
+func (m *managementFormatters) applyIPv4CIDR(cidr string) error {
+	address, network, prefixLen, err := parseCIDR(cidr)
 	if err != nil {
 		return err
 	}
 
-	address := prefix.Addr().String()
-	network := prefix.Masked().String()
-	prefixLen := strconv.Itoa(prefix.Bits())
+	m.ipv4 = cidr
+	m.ipv4Address = address
+	m.ipv4PrefixLen = prefixLen
+	m.ipv4Network = network
 
-	switch family {
-	case "ipv4":
-		m.ipv4 = cidr
-		m.ipv4Address = address
-		m.ipv4PrefixLen = prefixLen
-		m.ipv4Network = network
-	case "ipv6":
-		m.ipv6 = cidr
-		m.ipv6Address = address
-		m.ipv6PrefixLen = prefixLen
-		m.ipv6Network = network
+	return nil
+}
+
+// applyIPv6CIDR sets the IPv6 address, network, and prefix-length fields from the given CIDR.
+func (m *managementFormatters) applyIPv6CIDR(cidr string) error {
+	address, network, prefixLen, err := parseCIDR(cidr)
+	if err != nil {
+		return err
 	}
+
+	m.ipv6 = cidr
+	m.ipv6Address = address
+	m.ipv6PrefixLen = prefixLen
+	m.ipv6Network = network
 
 	return nil
 }

--- a/profile/formatters.go
+++ b/profile/formatters.go
@@ -1,12 +1,27 @@
 package profile
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"fmt"
+	"net/netip"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"text/template"
 
+	boxenconstants "github.com/carlmontanari/boxen/constants"
 	boxenerrors "github.com/carlmontanari/boxen/errors"
+	boxenutil "github.com/carlmontanari/boxen/util"
+)
+
+const (
+	defaultMgmtIPv4        = "10.0.0.15/24"
+	defaultMgmtIPv4Gateway = "10.0.0.2"
+	defaultMgmtIPv6        = "2001:db8::2/64"
+	defaultMgmtIPv6Gateway = "2001:db8::1"
 )
 
 // Formatters holds all the valid "formatter" options for string interpolation in profile content.
@@ -18,7 +33,47 @@ type Formatters struct {
 	password       string
 	hostname       string
 	connectionMode string
+	p              *Profile
+	isPackaging    bool
+
+	management *managementFormatters
 }
+
+type managementFormatters struct {
+	ipv4          string
+	ipv4Address   string
+	ipv4PrefixLen string
+	ipv4Network   string
+	ipv4Gateway   string
+	ipv6          string
+	ipv6Address   string
+	ipv6PrefixLen string
+	ipv6Network   string
+	ipv6Gateway   string
+}
+
+type ipAddressShowOutput []struct {
+	AddrInfo []struct {
+		Family    string `json:"family"`
+		Local     string `json:"local"`
+		PrefixLen int    `json:"prefixlen"`
+		Scope     string `json:"scope"`
+	} `json:"addr_info"`
+}
+
+type ipRouteShowDefaultOutput []struct {
+	Gateway string `json:"gateway"`
+}
+
+var (
+	ipAddressShowCommand = func(ctx context.Context, intf string) ([]byte, error) {
+		return exec.CommandContext(ctx, "ip", "--json", "address", "show", "dev", intf).Output() //nolint:gosec
+	}
+
+	ipRouteShowDefaultCommand = func(ctx context.Context, family string) ([]byte, error) {
+		return exec.CommandContext(ctx, "ip", "--json", family, "route", "show", "default").Output() //nolint:gosec
+	}
+)
 
 // NewFormatters returns a Formatters object based on the given inputs/profile.
 func NewFormatters(
@@ -27,6 +82,7 @@ func NewFormatters(
 	hostname,
 	connectionMode string,
 	p *Profile,
+	isPackaging bool,
 ) *Formatters {
 	// disk is always disk.qcow2 in "run" mode, but we maybe have a disk that we resolved
 	// during packaging, so override that if thats the case
@@ -52,6 +108,8 @@ func NewFormatters(
 		password:       password,
 		hostname:       hostname,
 		connectionMode: connectionMode,
+		p:              p,
+		isPackaging:    isPackaging,
 	}
 }
 
@@ -110,10 +168,296 @@ func (f *Formatters) UnpackFormatters(inputs []string) ([]any, error) {
 			}
 
 			formatters = append(formatters, f.hostname)
+		case strings.HasPrefix(formatter, "mgmt"):
+			v, err := f.managementFormatter(formatter)
+			if err != nil {
+				return nil, err
+			}
+
+			formatters = append(formatters, v)
 		default:
 			return nil, fmt.Errorf("%w: invalid formatter %q", boxenerrors.ErrBoxen, formatter)
 		}
 	}
 
 	return formatters, nil
+}
+
+// RenderTemplate renders write content with named Go template values.
+func (f *Formatters) RenderTemplate(content string) (string, error) {
+	if !strings.Contains(content, "{{") {
+		return content, nil
+	}
+
+	data, err := f.TemplateData(strings.Contains(content, "mgmt"))
+	if err != nil {
+		return "", err
+	}
+
+	t, err := template.New("content").Option("missingkey=error").Parse(content)
+	if err != nil {
+		return "", err
+	}
+
+	var b bytes.Buffer
+
+	err = t.Execute(&b, data)
+	if err != nil {
+		return "", err
+	}
+
+	return b.String(), nil
+}
+
+// TemplateData returns named values available to write content Go templates.
+func (f *Formatters) TemplateData(includeManagement bool) (map[string]any, error) {
+	data := map[string]any{
+		"disk":           f.disk,
+		"version":        f.version,
+		"extraFiles":     f.extraFiles,
+		"username":       f.username,
+		"password":       f.password,
+		"hostname":       f.hostname,
+		"connectionMode": f.connectionMode,
+	}
+
+	if !includeManagement {
+		return data, nil
+	}
+
+	management, err := f.getManagementFormatters()
+	if err != nil {
+		return nil, err
+	}
+
+	data["mgmtIPv4"] = management.ipv4
+	data["mgmtIPv4Address"] = management.ipv4Address
+	data["mgmtIPv4PrefixLen"] = management.ipv4PrefixLen
+	data["mgmtIPv4Network"] = management.ipv4Network
+	data["mgmtGatewayIPv4"] = management.ipv4Gateway
+	data["mgmtIPv6"] = management.ipv6
+	data["mgmtIPv6Address"] = management.ipv6Address
+	data["mgmtIPv6PrefixLen"] = management.ipv6PrefixLen
+	data["mgmtIPv6Network"] = management.ipv6Network
+	data["mgmtGatewayIPv6"] = management.ipv6Gateway
+
+	return data, nil
+}
+
+func (f *Formatters) managementFormatter(formatter string) (string, error) {
+	management, err := f.getManagementFormatters()
+	if err != nil {
+		return "", err
+	}
+
+	var v string
+
+	switch formatter {
+	case "mgmtIPv4":
+		v = management.ipv4
+	case "mgmtIPv4Address":
+		v = management.ipv4Address
+	case "mgmtIPv4PrefixLen":
+		v = management.ipv4PrefixLen
+	case "mgmtIPv4Network":
+		v = management.ipv4Network
+	case "mgmtGatewayIPv4":
+		v = management.ipv4Gateway
+	case "mgmtIPv6":
+		v = management.ipv6
+	case "mgmtIPv6Address":
+		v = management.ipv6Address
+	case "mgmtIPv6PrefixLen":
+		v = management.ipv6PrefixLen
+	case "mgmtIPv6Network":
+		v = management.ipv6Network
+	case "mgmtGatewayIPv6":
+		v = management.ipv6Gateway
+	default:
+		return "", fmt.Errorf("%w: invalid formatter %q", boxenerrors.ErrBoxen, formatter)
+	}
+
+	if v == "" && !strings.Contains(formatter, "IPv6") {
+		return "", fmt.Errorf("%w: formatter %q unset", boxenerrors.ErrBoxen, formatter)
+	}
+
+	return v, nil
+}
+
+func (f *Formatters) getManagementFormatters() (*managementFormatters, error) {
+	if f.management != nil {
+		return f.management, nil
+	}
+
+	switch {
+	case f.isPackaging:
+		f.management = defaultManagementFormatters()
+	case f.p == nil || f.p.VirtualMachine == nil:
+		f.management = defaultManagementFormatters()
+	case !f.p.VirtualMachine.EffectiveManagementPassthrough():
+		f.management = defaultManagementFormatters()
+	case envBoolTrue(boxenconstants.EnvClabMgmtDHCP):
+		f.management = dhcpManagementFormatters()
+	default:
+		management, err := runtimeManagementFormatters(context.Background())
+		if err != nil {
+			return nil, err
+		}
+
+		f.management = management
+	}
+
+	return f.management, nil
+}
+
+func defaultManagementFormatters() *managementFormatters {
+	management := &managementFormatters{
+		ipv4Gateway: defaultMgmtIPv4Gateway,
+		ipv6Gateway: defaultMgmtIPv6Gateway,
+	}
+
+	_ = management.applyCIDR(defaultMgmtIPv4, "ipv4")
+	_ = management.applyCIDR(defaultMgmtIPv6, "ipv6")
+
+	return management
+}
+
+func dhcpManagementFormatters() *managementFormatters {
+	return &managementFormatters{
+		ipv4:          "dhcp",
+		ipv4Address:   "dhcp",
+		ipv4PrefixLen: "dhcp",
+		ipv4Network:   "dhcp",
+		ipv4Gateway:   "dhcp",
+		ipv6:          "dhcp",
+		ipv6Address:   "dhcp",
+		ipv6PrefixLen: "dhcp",
+		ipv6Network:   "dhcp",
+		ipv6Gateway:   "dhcp",
+	}
+}
+
+func runtimeManagementFormatters(ctx context.Context) (*managementFormatters, error) {
+	intfPrefix := boxenutil.GetEnvStrOrDefault(boxenconstants.EnvClabIntfPrefix, "eth")
+	management := &managementFormatters{}
+
+	err := management.setRuntimeAddresses(ctx, fmt.Sprintf("%s0", intfPrefix))
+	if err != nil {
+		return nil, err
+	}
+
+	err = management.setRuntimeGateways(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return management, nil
+}
+
+func (m *managementFormatters) setRuntimeAddresses(ctx context.Context, intf string) error {
+	b, err := ipAddressShowCommand(ctx, intf)
+	if err != nil {
+		return err
+	}
+
+	var o ipAddressShowOutput
+
+	err = json.Unmarshal(b, &o)
+	if err != nil {
+		return err
+	}
+
+	for _, link := range o {
+		for _, addrInfo := range link.AddrInfo {
+			if addrInfo.Scope != "global" {
+				continue
+			}
+
+			cidr := fmt.Sprintf("%s/%d", addrInfo.Local, addrInfo.PrefixLen)
+
+			switch addrInfo.Family {
+			case "inet":
+				err = m.applyCIDR(cidr, "ipv4")
+			case "inet6":
+				err = m.applyCIDR(cidr, "ipv6")
+			default:
+				continue
+			}
+
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (m *managementFormatters) setRuntimeGateways(ctx context.Context) error {
+	ipv4Gateway, err := runtimeDefaultGateway(ctx, "-4")
+	if err != nil {
+		return err
+	}
+
+	ipv6Gateway, err := runtimeDefaultGateway(ctx, "-6")
+	if err != nil {
+		return err
+	}
+
+	m.ipv4Gateway = ipv4Gateway
+	m.ipv6Gateway = ipv6Gateway
+
+	return nil
+}
+
+func runtimeDefaultGateway(ctx context.Context, family string) (string, error) {
+	b, err := ipRouteShowDefaultCommand(ctx, family)
+	if err != nil {
+		return "", err
+	}
+
+	var o ipRouteShowDefaultOutput
+
+	err = json.Unmarshal(b, &o)
+	if err != nil {
+		return "", err
+	}
+
+	if len(o) == 0 {
+		return "", nil
+	}
+
+	return o[0].Gateway, nil
+}
+
+func (m *managementFormatters) applyCIDR(cidr, family string) error {
+	prefix, err := netip.ParsePrefix(cidr)
+	if err != nil {
+		return err
+	}
+
+	address := prefix.Addr().String()
+	network := prefix.Masked().String()
+	prefixLen := strconv.Itoa(prefix.Bits())
+
+	switch family {
+	case "ipv4":
+		m.ipv4 = cidr
+		m.ipv4Address = address
+		m.ipv4PrefixLen = prefixLen
+		m.ipv4Network = network
+	case "ipv6":
+		m.ipv6 = cidr
+		m.ipv6Address = address
+		m.ipv6PrefixLen = prefixLen
+		m.ipv6Network = network
+	}
+
+	return nil
+}
+
+func envBoolTrue(k string) bool {
+	v := boxenutil.GetEnvStrOrDefault(k, "")
+
+	return strings.ToLower(v) == "true"
 }

--- a/profile/formatters.go
+++ b/profile/formatters.go
@@ -190,12 +190,12 @@ func (f *Formatters) RenderTemplate(content string) (string, error) {
 		return content, nil
 	}
 
-	data, err := f.TemplateData(strings.Contains(content, "mgmt"))
+	t, err := template.New("content").Option("missingkey=error").Parse(content)
 	if err != nil {
 		return "", err
 	}
 
-	t, err := template.New("content").Option("missingkey=error").Parse(content)
+	data, err := f.TemplateData()
 	if err != nil {
 		return "", err
 	}
@@ -211,7 +211,7 @@ func (f *Formatters) RenderTemplate(content string) (string, error) {
 }
 
 // TemplateData returns named values available to write content Go templates.
-func (f *Formatters) TemplateData(includeManagement bool) (map[string]any, error) {
+func (f *Formatters) TemplateData() (map[string]any, error) {
 	data := map[string]any{
 		"disk":           f.disk,
 		"version":        f.version,
@@ -220,10 +220,6 @@ func (f *Formatters) TemplateData(includeManagement bool) (map[string]any, error
 		"password":       f.password,
 		"hostname":       f.hostname,
 		"connectionMode": f.connectionMode,
-	}
-
-	if !includeManagement {
-		return data, nil
 	}
 
 	management, err := f.getManagementFormatters()
@@ -325,6 +321,8 @@ func (f *Formatters) getManagementFormatters() (*managementFormatters, error) {
 	return f.management, nil
 }
 
+// defaultManagementFormatters returns the default management formatters.
+// It sets the default IPv4 and IPv6 gateways and applies the default CIDRs to the managementFormatters struct.
 func defaultManagementFormatters() *managementFormatters {
 	management := &managementFormatters{
 		ipv4Gateway: defaultMgmtIPv4Gateway,
@@ -360,6 +358,8 @@ func runtimeManagementFormatters(ctx context.Context) (*managementFormatters, er
 	return management, nil
 }
 
+// setRuntimeAddresses sets the runtime addresses for the managementFormatters struct.
+// It reads the addresses for the given interface and sets the appropriate fields in the managementFormatters struct.
 func (m *managementFormatters) setRuntimeAddresses(ctx context.Context, intf string) error {
 	b, err := ipAddressShowCommand(ctx, intf)
 	if err != nil {
@@ -399,6 +399,8 @@ func (m *managementFormatters) setRuntimeAddresses(ctx context.Context, intf str
 	return nil
 }
 
+// setRuntimeGateways sets the runtime default gateways for the managementFormatters struct.
+// It reads the default routes for IPv4 and IPv6 and sets the appropriate fields in the managementFormatters struct.
 func (m *managementFormatters) setRuntimeGateways(ctx context.Context) error {
 	ipv4Gateway, err := runtimeDefaultGateway(ctx, "-4")
 	if err != nil {
@@ -416,6 +418,8 @@ func (m *managementFormatters) setRuntimeGateways(ctx context.Context) error {
 	return nil
 }
 
+// runtimeDefaultGateway returns the default gateway for the given family.
+// It reads the default route for the given family and returns the gateway IP address.
 func runtimeDefaultGateway(ctx context.Context, family string) (string, error) {
 	b, err := ipRouteShowDefaultCommand(ctx, family)
 	if err != nil {
@@ -436,6 +440,8 @@ func runtimeDefaultGateway(ctx context.Context, family string) (string, error) {
 	return o[0].Gateway, nil
 }
 
+// applyCIDR applies the CIDR to the managementFormatters struct for the given family.
+// It parses the CIDR, extracts the address, network, and prefix length, and sets the appropriate fields in the managementFormatters struct.
 func (m *managementFormatters) applyCIDR(cidr, family string) error {
 	prefix, err := netip.ParsePrefix(cidr)
 	if err != nil {

--- a/profile/formatters.go
+++ b/profile/formatters.go
@@ -294,7 +294,7 @@ func (f *Formatters) getManagementFormatters() (*managementFormatters, error) {
 		f.management = defaultManagementFormatters()
 	case f.p == nil || f.p.VirtualMachine == nil:
 		f.management = defaultManagementFormatters()
-	case !f.p.VirtualMachine.EffectiveManagementPassthrough():
+	case !f.p.VirtualMachine.IsManagementPassthroughEnabled():
 		f.management = defaultManagementFormatters()
 	case envBoolTrue(boxenconstants.EnvClabMgmtDHCP):
 		f.management = dhcpManagementFormatters()

--- a/profile/formatters_test.go
+++ b/profile/formatters_test.go
@@ -2,49 +2,30 @@ package profile
 
 import (
 	"context"
-	"reflect"
-	"strings"
 	"testing"
 
 	boxenconstants "github.com/carlmontanari/boxen/constants"
 )
+
+const mgmtTemplate = `{{ .mgmtIPv4 }} {{ .mgmtIPv4Address }} {{ .mgmtIPv4PrefixLen }} ` +
+	`{{ .mgmtIPv4Network }} {{ .mgmtIPv4Gateway }} {{ .mgmtIPv6 }} {{ .mgmtIPv6Address }} ` +
+	`{{ .mgmtIPv6PrefixLen }} {{ .mgmtIPv6Network }} {{ .mgmtIPv6Gateway }}`
 
 func TestManagementFormattersDefault(t *testing.T) {
 	t.Setenv(boxenconstants.EnvClabMgmtPassthrough, "")
 
 	f := NewFormatters("", "", "", "", testQemuProfile(true), true)
 
-	actual, err := f.UnpackFormatters([]string{
-		"mgmtIPv4",
-		"mgmtIPv4Address",
-		"mgmtIPv4PrefixLen",
-		"mgmtIPv4Network",
-		"mgmtIPv4Gateway",
-		"mgmtIPv6",
-		"mgmtIPv6Address",
-		"mgmtIPv6PrefixLen",
-		"mgmtIPv6Network",
-		"mgmtIPv6Gateway",
-	})
+	actual, err := f.RenderTemplate(mgmtTemplate)
 	if err != nil {
-		t.Fatalf("unpacking management formatters failed: %v", err)
+		t.Fatalf("rendering management formatters failed: %v", err)
 	}
 
-	expected := []any{
-		"10.0.0.15/24",
-		"10.0.0.15",
-		"24",
-		"10.0.0.0/24",
-		"10.0.0.2",
-		"2001:db8::2/64",
-		"2001:db8::2",
-		"64",
-		"2001:db8::/64",
-		"2001:db8::1",
-	}
+	expected := "10.0.0.15/24 10.0.0.15 24 10.0.0.0/24 10.0.0.2 " +
+		"2001:db8::2/64 2001:db8::2 64 2001:db8::/64 2001:db8::1"
 
-	if !reflect.DeepEqual(actual, expected) {
-		t.Fatalf("management formatters mismatch, got %#v, want %#v", actual, expected)
+	if actual != expected {
+		t.Fatalf("management formatters mismatch, got %q, want %q", actual, expected)
 	}
 }
 
@@ -93,53 +74,37 @@ func TestManagementFormattersRuntime(t *testing.T) {
 
 	f := NewFormatters("", "", "", "", testQemuProfile(false), false)
 
-	actual, err := f.UnpackFormatters([]string{
-		"mgmtIPv4",
-		"mgmtIPv4Address",
-		"mgmtIPv4PrefixLen",
-		"mgmtIPv4Network",
-		"mgmtIPv4Gateway",
-		"mgmtIPv6",
-		"mgmtIPv6Address",
-		"mgmtIPv6PrefixLen",
-		"mgmtIPv6Network",
-		"mgmtIPv6Gateway",
-	})
+	actual, err := f.RenderTemplate(mgmtTemplate)
 	if err != nil {
-		t.Fatalf("unpacking management formatters failed: %v", err)
+		t.Fatalf("rendering management formatters failed: %v", err)
 	}
 
-	expected := []any{
-		"172.20.20.10/24",
-		"172.20.20.10",
-		"24",
-		"172.20.20.0/24",
-		"172.20.20.1",
-		"2001:db8:20::10/64",
-		"2001:db8:20::10",
-		"64",
-		"2001:db8:20::/64",
-		"2001:db8:20::1",
-	}
+	expected := "172.20.20.10/24 172.20.20.10 24 172.20.20.0/24 172.20.20.1 " +
+		"2001:db8:20::10/64 2001:db8:20::10 64 2001:db8:20::/64 2001:db8:20::1"
 
-	if !reflect.DeepEqual(actual, expected) {
-		t.Fatalf("management formatters mismatch, got %#v, want %#v", actual, expected)
+	if actual != expected {
+		t.Fatalf("management formatters mismatch, got %q, want %q", actual, expected)
 	}
 }
 
-func TestManagementFormattersDHCP(t *testing.T) {
-	t.Setenv(boxenconstants.EnvClabMgmtPassthrough, "true")
-	t.Setenv(boxenconstants.EnvClabMgmtDHCP, "true")
-
-	f := NewFormatters("", "", "", "", testQemuProfile(false), false)
-
-	_, err := f.UnpackFormatters([]string{"mgmtIPv4"})
-	if err == nil {
-		t.Fatal("expected positional management formatter to fail in DHCP mode")
+func TestRenderTemplateExtraFiles(t *testing.T) {
+	p := &Profile{
+		Name:           "test",
+		ExtraFiles:     []string{"/some/dir/license.lic", "startup.cfg"},
+		VirtualMachine: &VirtualMachine{},
 	}
 
-	if !strings.Contains(err.Error(), boxenconstants.EnvClabMgmtDHCP) {
-		t.Fatalf("expected DHCP error, got %v", err)
+	f := NewFormatters("", "", "", "", p, true)
+
+	actual, err := f.RenderTemplate(`{{ index .extraFiles 0 }} {{ index .extraFiles 1 }}`)
+	if err != nil {
+		t.Fatalf("rendering extraFiles template failed: %v", err)
+	}
+
+	expected := "license.lic startup.cfg"
+
+	if actual != expected {
+		t.Fatalf("extraFiles mismatch, got %q, want %q", actual, expected)
 	}
 }
 
@@ -221,31 +186,5 @@ func TestRenderTemplateDHCPManagementFormatters(t *testing.T) {
 	_, err = f.RenderTemplate(`address {{ .mgmtIPv4 }}`)
 	if err == nil {
 		t.Fatal("expected direct management address use to fail in DHCP mode")
-	}
-}
-
-func TestUnpackExtraFileFormatter(t *testing.T) {
-	p := &Profile{
-		Name:           "test",
-		ExtraFiles:     []string{"/some/dir/license.lic", "startup.cfg"},
-		VirtualMachine: &VirtualMachine{},
-	}
-
-	f := NewFormatters("", "", "", "", p, true)
-
-	actual, err := f.UnpackFormatters([]string{"extraFile[0]", "extraFile[1]"})
-	if err != nil {
-		t.Fatalf("unpacking extraFile formatters failed: %v", err)
-	}
-
-	expected := []any{"license.lic", "startup.cfg"}
-
-	if !reflect.DeepEqual(actual, expected) {
-		t.Fatalf("extraFile formatters mismatch, got %#v, want %#v", actual, expected)
-	}
-
-	_, err = f.UnpackFormatters([]string{"extraFile[2]"})
-	if err == nil {
-		t.Fatal("expected out-of-range extraFile index to error")
 	}
 }

--- a/profile/formatters_test.go
+++ b/profile/formatters_test.go
@@ -74,7 +74,11 @@ func TestManagementFormattersRuntime(t *testing.T) {
 		]`), nil
 	}
 
-	ipRouteShowDefaultCommand = func(_ context.Context, family string) ([]byte, error) {
+	ipRouteShowDefaultCommand = func(_ context.Context, family, intf string) ([]byte, error) {
+		if intf != "eth0" {
+			t.Fatalf("unexpected management interface %q", intf)
+		}
+
 		switch family {
 		case "-4":
 			return []byte(`[{"gateway": "172.20.20.1"}]`), nil
@@ -160,7 +164,7 @@ func TestRenderTemplateManagementFormatters(t *testing.T) {
 		]`), nil
 	}
 
-	ipRouteShowDefaultCommand = func(_ context.Context, family string) ([]byte, error) {
+	ipRouteShowDefaultCommand = func(_ context.Context, family, _ string) ([]byte, error) {
 		switch family {
 		case "-4":
 			return []byte(`[{"gateway": "172.20.20.1"}]`), nil
@@ -217,5 +221,31 @@ func TestRenderTemplateDHCPManagementFormatters(t *testing.T) {
 	_, err = f.RenderTemplate(`address {{ .mgmtIPv4 }}`)
 	if err == nil {
 		t.Fatal("expected direct management address use to fail in DHCP mode")
+	}
+}
+
+func TestUnpackExtraFileFormatter(t *testing.T) {
+	p := &Profile{
+		Name:           "test",
+		ExtraFiles:     []string{"/some/dir/license.lic", "startup.cfg"},
+		VirtualMachine: &VirtualMachine{},
+	}
+
+	f := NewFormatters("", "", "", "", p, true)
+
+	actual, err := f.UnpackFormatters([]string{"extraFile[0]", "extraFile[1]"})
+	if err != nil {
+		t.Fatalf("unpacking extraFile formatters failed: %v", err)
+	}
+
+	expected := []any{"license.lic", "startup.cfg"}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("extraFile formatters mismatch, got %#v, want %#v", actual, expected)
+	}
+
+	_, err = f.UnpackFormatters([]string{"extraFile[2]"})
+	if err == nil {
+		t.Fatal("expected out-of-range extraFile index to error")
 	}
 }

--- a/profile/formatters_test.go
+++ b/profile/formatters_test.go
@@ -1,0 +1,179 @@
+package profile
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	boxenconstants "github.com/carlmontanari/boxen/constants"
+)
+
+func TestManagementFormattersDefault(t *testing.T) {
+	t.Setenv(boxenconstants.EnvClabMgmtPassthrough, "")
+
+	f := NewFormatters("", "", "", "", testQemuProfile(true), true)
+
+	actual, err := f.UnpackFormatters([]string{
+		"mgmtIPv4",
+		"mgmtIPv4Address",
+		"mgmtIPv4PrefixLen",
+		"mgmtIPv4Network",
+		"mgmtGatewayIPv4",
+		"mgmtIPv6",
+		"mgmtIPv6Address",
+		"mgmtIPv6PrefixLen",
+		"mgmtIPv6Network",
+		"mgmtGatewayIPv6",
+	})
+	if err != nil {
+		t.Fatalf("unpacking management formatters failed: %v", err)
+	}
+
+	expected := []any{
+		"10.0.0.15/24",
+		"10.0.0.15",
+		"24",
+		"10.0.0.0/24",
+		"10.0.0.2",
+		"2001:db8::2/64",
+		"2001:db8::2",
+		"64",
+		"2001:db8::/64",
+		"2001:db8::1",
+	}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("management formatters mismatch, got %#v, want %#v", actual, expected)
+	}
+}
+
+func TestManagementFormattersRuntime(t *testing.T) {
+	t.Setenv(boxenconstants.EnvClabMgmtPassthrough, "true")
+
+	oldAddressShowCommand := ipAddressShowCommand
+	oldRouteShowDefaultCommand := ipRouteShowDefaultCommand
+
+	t.Cleanup(func() {
+		ipAddressShowCommand = oldAddressShowCommand
+		ipRouteShowDefaultCommand = oldRouteShowDefaultCommand
+	})
+
+	ipAddressShowCommand = func(_ context.Context, intf string) ([]byte, error) {
+		if intf != "eth0" {
+			t.Fatalf("unexpected management interface %q", intf)
+		}
+
+		return []byte(`[
+			{
+				"addr_info": [
+					{"family": "inet", "local": "172.20.20.10", "prefixlen": 24, "scope": "global"},
+					{"family": "inet6", "local": "2001:db8:20::10", "prefixlen": 64, "scope": "global"}
+				]
+			}
+		]`), nil
+	}
+
+	ipRouteShowDefaultCommand = func(_ context.Context, family string) ([]byte, error) {
+		switch family {
+		case "-4":
+			return []byte(`[{"gateway": "172.20.20.1"}]`), nil
+		case "-6":
+			return []byte(`[{"gateway": "2001:db8:20::1"}]`), nil
+		default:
+			t.Fatalf("unexpected route family %q", family)
+		}
+
+		return nil, nil
+	}
+
+	f := NewFormatters("", "", "", "", testQemuProfile(false), false)
+
+	actual, err := f.UnpackFormatters([]string{
+		"mgmtIPv4",
+		"mgmtIPv4Address",
+		"mgmtIPv4PrefixLen",
+		"mgmtIPv4Network",
+		"mgmtGatewayIPv4",
+		"mgmtIPv6",
+		"mgmtIPv6Address",
+		"mgmtIPv6PrefixLen",
+		"mgmtIPv6Network",
+		"mgmtGatewayIPv6",
+	})
+	if err != nil {
+		t.Fatalf("unpacking management formatters failed: %v", err)
+	}
+
+	expected := []any{
+		"172.20.20.10/24",
+		"172.20.20.10",
+		"24",
+		"172.20.20.0/24",
+		"172.20.20.1",
+		"2001:db8:20::10/64",
+		"2001:db8:20::10",
+		"64",
+		"2001:db8:20::/64",
+		"2001:db8:20::1",
+	}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("management formatters mismatch, got %#v, want %#v", actual, expected)
+	}
+}
+
+func TestRenderTemplateManagementFormatters(t *testing.T) {
+	t.Setenv(boxenconstants.EnvClabMgmtPassthrough, "true")
+
+	oldAddressShowCommand := ipAddressShowCommand
+	oldRouteShowDefaultCommand := ipRouteShowDefaultCommand
+
+	t.Cleanup(func() {
+		ipAddressShowCommand = oldAddressShowCommand
+		ipRouteShowDefaultCommand = oldRouteShowDefaultCommand
+	})
+
+	ipAddressShowCommand = func(_ context.Context, _ string) ([]byte, error) {
+		return []byte(`[
+			{
+				"addr_info": [
+					{"family": "inet", "local": "172.20.20.10", "prefixlen": 24, "scope": "global"}
+				]
+			}
+		]`), nil
+	}
+
+	ipRouteShowDefaultCommand = func(_ context.Context, family string) ([]byte, error) {
+		switch family {
+		case "-4":
+			return []byte(`[{"gateway": "172.20.20.1"}]`), nil
+		case "-6":
+			return []byte(`[]`), nil
+		default:
+			t.Fatalf("unexpected route family %q", family)
+		}
+
+		return nil, nil
+	}
+
+	f := NewFormatters("", "", "leaf1", "", testQemuProfile(false), false)
+
+	actual, err := f.RenderTemplate(
+		`hostname {{ .hostname }}
+address {{ .mgmtIPv4Address }}
+network {{ .mgmtIPv4Network }}
+ipv6 {{ .mgmtIPv6Address }}`,
+	)
+	if err != nil {
+		t.Fatalf("rendering template failed: %v", err)
+	}
+
+	expected := `hostname leaf1
+address 172.20.20.10
+network 172.20.20.0/24
+ipv6 `
+
+	if actual != expected {
+		t.Fatalf("rendered template mismatch, got %q, want %q", actual, expected)
+	}
+}

--- a/profile/formatters_test.go
+++ b/profile/formatters_test.go
@@ -19,12 +19,12 @@ func TestManagementFormattersDefault(t *testing.T) {
 		"mgmtIPv4Address",
 		"mgmtIPv4PrefixLen",
 		"mgmtIPv4Network",
-		"mgmtGatewayIPv4",
+		"mgmtIPv4Gateway",
 		"mgmtIPv6",
 		"mgmtIPv6Address",
 		"mgmtIPv6PrefixLen",
 		"mgmtIPv6Network",
-		"mgmtGatewayIPv6",
+		"mgmtIPv6Gateway",
 	})
 	if err != nil {
 		t.Fatalf("unpacking management formatters failed: %v", err)
@@ -98,12 +98,12 @@ func TestManagementFormattersRuntime(t *testing.T) {
 		"mgmtIPv4Address",
 		"mgmtIPv4PrefixLen",
 		"mgmtIPv4Network",
-		"mgmtGatewayIPv4",
+		"mgmtIPv4Gateway",
 		"mgmtIPv6",
 		"mgmtIPv6Address",
 		"mgmtIPv6PrefixLen",
 		"mgmtIPv6Network",
-		"mgmtGatewayIPv6",
+		"mgmtIPv6Gateway",
 	})
 	if err != nil {
 		t.Fatalf("unpacking management formatters failed: %v", err)

--- a/profile/formatters_test.go
+++ b/profile/formatters_test.go
@@ -3,6 +3,7 @@ package profile
 import (
 	"context"
 	"reflect"
+	"strings"
 	"testing"
 
 	boxenconstants "github.com/carlmontanari/boxen/constants"
@@ -122,6 +123,22 @@ func TestManagementFormattersRuntime(t *testing.T) {
 	}
 }
 
+func TestManagementFormattersDHCP(t *testing.T) {
+	t.Setenv(boxenconstants.EnvClabMgmtPassthrough, "true")
+	t.Setenv(boxenconstants.EnvClabMgmtDHCP, "true")
+
+	f := NewFormatters("", "", "", "", testQemuProfile(false), false)
+
+	_, err := f.UnpackFormatters([]string{"mgmtIPv4"})
+	if err == nil {
+		t.Fatal("expected positional management formatter to fail in DHCP mode")
+	}
+
+	if !strings.Contains(err.Error(), boxenconstants.EnvClabMgmtDHCP) {
+		t.Fatalf("expected DHCP error, got %v", err)
+	}
+}
+
 func TestRenderTemplateManagementFormatters(t *testing.T) {
 	t.Setenv(boxenconstants.EnvClabMgmtPassthrough, "true")
 
@@ -175,5 +192,30 @@ ipv6 `
 
 	if actual != expected {
 		t.Fatalf("rendered template mismatch, got %q, want %q", actual, expected)
+	}
+}
+
+func TestRenderTemplateDHCPManagementFormatters(t *testing.T) {
+	t.Setenv(boxenconstants.EnvClabMgmtPassthrough, "true")
+	t.Setenv(boxenconstants.EnvClabMgmtDHCP, "true")
+
+	f := NewFormatters("", "", "", "", testQemuProfile(false), false)
+
+	actual, err := f.RenderTemplate(
+		`{{ if .mgmtDHCP }}address dhcp{{ else }}address {{ .mgmtIPv4 }}{{ end }}`,
+	)
+	if err != nil {
+		t.Fatalf("rendering DHCP template failed: %v", err)
+	}
+
+	expected := `address dhcp`
+
+	if actual != expected {
+		t.Fatalf("rendered template mismatch, got %q, want %q", actual, expected)
+	}
+
+	_, err = f.RenderTemplate(`address {{ .mgmtIPv4 }}`)
+	if err == nil {
+		t.Fatal("expected direct management address use to fail in DHCP mode")
 	}
 }

--- a/profile/qemu.go
+++ b/profile/qemu.go
@@ -286,8 +286,7 @@ func qemuMgmtNIC(p *Profile, isPackaging bool) []string {
 	if managementPassthrough {
 		mac = os.Getenv(boxenconstants.EnvClabMgmtMAC)
 		if mac == "" {
-			intfPrefix := boxenutil.GetEnvStrOrDefault(boxenconstants.EnvClabIntfPrefix, "eth")
-			mac = getIntfMac(context.Background(), fmt.Sprintf("%s0", intfPrefix))
+			mac = getIntfMac(context.Background(), boxenutil.ClabMgmtIntfName())
 		}
 
 		if mac == "" {
@@ -363,9 +362,9 @@ func buildDataNic(
 	busAddr int,
 	paddedNicID string,
 ) []string {
-	intfPrefix := boxenutil.GetEnvStrOrDefault(boxenconstants.EnvClabIntfPrefix, "eth")
+	intfName := boxenutil.ClabIntfName(nicID)
 
-	_, err := os.Stat(fmt.Sprintf("/sys/class/net/%s%d", intfPrefix, nicID))
+	_, err := os.Stat(fmt.Sprintf("/sys/class/net/%s", intfName))
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return []string{
@@ -385,7 +384,7 @@ func buildDataNic(
 	}
 
 	// try to get the mac from the container interface so things match in bridge mode
-	mac := getIntfMac(context.Background(), fmt.Sprintf("%s%d", intfPrefix, nicID))
+	mac := getIntfMac(context.Background(), intfName)
 	if mac == "" {
 		mac = generateMac(nicID)
 	}

--- a/profile/qemu.go
+++ b/profile/qemu.go
@@ -48,7 +48,6 @@ const (
 // QemuArgsFromProfile builds the qemu launch args from the given profile/disk.
 func QemuArgsFromProfile(
 	p *Profile,
-	formatters *Formatters,
 	isPackaging bool,
 ) ([]string, error) {
 	out := []string{
@@ -88,12 +87,7 @@ func QemuArgsFromProfile(
 		kOverrides, ok := p.VirtualMachine.Overrides[k]
 		if ok {
 			for _, o := range kOverrides {
-				var err error
-
-				out, err = o.Apply(formatters, isPackaging, out)
-				if err != nil {
-					return nil, err
-				}
+				out = o.Apply(isPackaging, out)
 			}
 
 			continue
@@ -122,12 +116,7 @@ func QemuArgsFromProfile(
 	}
 
 	for _, e := range p.VirtualMachine.Extras {
-		var err error
-
-		out, err = e.Apply(formatters, isPackaging, out)
-		if err != nil {
-			return nil, err
-		}
+		out = e.Apply(isPackaging, out)
 	}
 
 	qemuAdditionalArgs := os.Getenv(boxenconstants.EnvClabQemuAdditionalArgs)

--- a/profile/qemu.go
+++ b/profile/qemu.go
@@ -280,7 +280,7 @@ func qemuPCI(p *Profile) []string {
 }
 
 func qemuMgmtNIC(p *Profile, isPackaging bool) []string {
-	managementPassthrough := !isPackaging && p.VirtualMachine.EffectiveManagementPassthrough()
+	managementPassthrough := !isPackaging && p.VirtualMachine.IsManagementPassthroughEnabled()
 	mac := ""
 
 	if managementPassthrough {

--- a/profile/qemu.go
+++ b/profile/qemu.go
@@ -38,8 +38,9 @@ const (
 	monitorPort       = 4_001
 	serialPortBaseIdx = 5_001
 
-	defaultSocketPad = 10_000
-	tcTapIfupScript  = "/etc/tc-tap-ifup"
+	defaultSocketPad    = 10_000
+	tcTapIfupScript     = "/etc/tc-tap-ifup"
+	tcTapMgmtIfupScript = "/etc/tc-tap-mgmt-ifup"
 
 	accelerationKVM = "kvm"
 )
@@ -67,7 +68,6 @@ func QemuArgsFromProfile(
 		monitor:      qemuMonitor,
 		display:      qemuDisplay,
 		pci:          qemuPCI,
-		mgmtNIC:      qemuMgmtNIC,
 		dataNICs:     qemuDataNICs,
 	}
 
@@ -99,7 +99,12 @@ func QemuArgsFromProfile(
 			continue
 		}
 
-		args := fs[k](p)
+		var args []string
+		if k == mgmtNIC {
+			args = qemuMgmtNIC(p, isPackaging)
+		} else {
+			args = fs[k](p)
+		}
 
 		fBody, mutateOk := p.VirtualMachine.Mutators[k]
 		if !mutateOk {
@@ -274,16 +279,41 @@ func qemuPCI(p *Profile) []string {
 	return pciCmd
 }
 
-func qemuMgmtNIC(p *Profile) []string {
-	if p.VirtualMachine.ManagementPassthrough {
-		panic("not implemented")
+func qemuMgmtNIC(p *Profile, isPackaging bool) []string {
+	managementPassthrough := !isPackaging && p.VirtualMachine.EffectiveManagementPassthrough()
+	mac := ""
+
+	if managementPassthrough {
+		mac = os.Getenv(boxenconstants.EnvClabMgmtMAC)
+		if mac == "" {
+			intfPrefix := boxenutil.GetEnvStrOrDefault(boxenconstants.EnvClabIntfPrefix, "eth")
+			mac = getIntfMac(context.Background(), fmt.Sprintf("%s0", intfPrefix))
+		}
+
+		if mac == "" {
+			mac = generateMac(0)
+		}
+	}
+
+	deviceArgs := fmt.Sprintf("%s,netdev=mgmt", p.VirtualMachine.NicType)
+	if mac != "" {
+		deviceArgs = fmt.Sprintf("%s,mac=%s", deviceArgs, mac)
 	}
 
 	nicCmd := []string{
 		device,
-		fmt.Sprintf("%s,netdev=mgmt", p.VirtualMachine.NicType),
+		deviceArgs,
 		"-netdev",
 		"",
+	}
+
+	if managementPassthrough {
+		nicCmd[3] = fmt.Sprintf(
+			"tap,id=mgmt,ifname=tap0,script=%s,downscript=no",
+			tcTapMgmtIfupScript,
+		)
+
+		return nicCmd
 	}
 
 	mgmtIntf := "user,id=mgmt,net=10.0.0.0/24,host=10.0.0.2," +
@@ -400,11 +430,6 @@ type ipLinkShowOutput []struct {
 
 func getIntfMac(ctx context.Context, intf string) string {
 	cmd := exec.CommandContext(ctx, "ip", "--json", "link", "show", "dev", intf) //nolint: gosec
-
-	err := cmd.Run()
-	if err != nil {
-		return ""
-	}
 
 	b, err := cmd.Output()
 	if err != nil {

--- a/profile/qemu_test.go
+++ b/profile/qemu_test.go
@@ -1,6 +1,7 @@
 package profile
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
@@ -80,5 +81,82 @@ func testQemuProfile(managementPassthrough bool) *Profile {
 				},
 			},
 		},
+	}
+}
+
+func TestQemuArgsOverridesAndExtras(t *testing.T) {
+	t.Setenv(boxenconstants.EnvClabMgmtPassthrough, "")
+
+	p := &Profile{
+		Name: "test",
+		VirtualMachine: &VirtualMachine{
+			NicType:   "virtio-net-pci",
+			NicCount:  1,
+			NicPerBus: 26,
+			Overrides: map[string][]QemuConfigField{
+				disk: {
+					{
+						OnPackage: true,
+						OnRun:     true,
+						Val: []QemuConfigVal{
+							{Content: "-drive"},
+							{Content: "if=none,file=disk.qcow2,format=qcow2,id=drive0"},
+						},
+					},
+				},
+			},
+			Extras: []QemuConfigField{
+				{
+					OnPackage: true,
+					OnRun:     true,
+					Val: []QemuConfigVal{
+						{Content: "-bios"},
+						{Content: "OVMF.fd"},
+					},
+				},
+				{
+					OnPackage: true,
+					OnRun:     false,
+					Val: []QemuConfigVal{
+						{Content: "-cdrom"},
+						{Content: "config.iso"},
+					},
+				},
+			},
+		},
+	}
+
+	runArgs, err := QemuArgsFromProfile(p, false)
+	if err != nil {
+		t.Fatalf("building run qemu args failed: %v", err)
+	}
+
+	// the override replaces the default disk section entirely
+	if !slices.Contains(runArgs, "if=none,file=disk.qcow2,format=qcow2,id=drive0") {
+		t.Fatalf("expected disk override content in run args, got %v", runArgs)
+	}
+
+	if slices.Contains(runArgs, "if=ide,file=disk.qcow2,format=qcow2") {
+		t.Fatalf("default disk args should be replaced by the override, got %v", runArgs)
+	}
+
+	// an onRun extra is appended in run mode
+	if !slices.Contains(runArgs, "-bios") || !slices.Contains(runArgs, "OVMF.fd") {
+		t.Fatalf("expected onRun extra (-bios OVMF.fd) in run args, got %v", runArgs)
+	}
+
+	// an onPackage-only extra is gated out in run mode
+	if slices.Contains(runArgs, "config.iso") {
+		t.Fatalf("onPackage-only extra should be absent in run args, got %v", runArgs)
+	}
+
+	packageArgs, err := QemuArgsFromProfile(p, true)
+	if err != nil {
+		t.Fatalf("building packaging qemu args failed: %v", err)
+	}
+
+	// the onPackage-only extra is present in packaging mode
+	if !slices.Contains(packageArgs, "-cdrom") || !slices.Contains(packageArgs, "config.iso") {
+		t.Fatalf("expected onPackage extra in packaging args, got %v", packageArgs)
 	}
 }

--- a/profile/qemu_test.go
+++ b/profile/qemu_test.go
@@ -1,0 +1,84 @@
+package profile
+
+import (
+	"strings"
+	"testing"
+
+	boxenconstants "github.com/carlmontanari/boxen/constants"
+)
+
+func TestQemuMgmtNICLegacyNat(t *testing.T) {
+	t.Setenv(boxenconstants.EnvClabMgmtPassthrough, "")
+
+	args := qemuMgmtNIC(testQemuProfile(false), false)
+
+	if !strings.Contains(args[3], "user,id=mgmt") {
+		t.Fatalf("management netdev should use user networking, got %q", args[3])
+	}
+
+	if !strings.Contains(args[3], "hostfwd=tcp:0.0.0.0:22-10.0.0.15:22") {
+		t.Fatalf("management netdev missing NAT hostfwd, got %q", args[3])
+	}
+}
+
+func TestQemuMgmtNICProfilePassthrough(t *testing.T) {
+	t.Setenv(boxenconstants.EnvClabMgmtPassthrough, "")
+	t.Setenv(boxenconstants.EnvClabMgmtMAC, "02:00:00:00:00:01")
+
+	args := qemuMgmtNIC(testQemuProfile(true), false)
+
+	if !strings.Contains(args[1], "mac=02:00:00:00:00:01") {
+		t.Fatalf("management device missing MAC, got %q", args[1])
+	}
+
+	if args[3] != "tap,id=mgmt,ifname=tap0,script=/etc/tc-tap-mgmt-ifup,downscript=no" {
+		t.Fatalf("management netdev should use tap0, got %q", args[3])
+	}
+}
+
+func TestQemuMgmtNICEnvPassthroughOverrideTrue(t *testing.T) {
+	t.Setenv(boxenconstants.EnvClabMgmtPassthrough, "true")
+	t.Setenv(boxenconstants.EnvClabMgmtMAC, "02:00:00:00:00:02")
+
+	args := qemuMgmtNIC(testQemuProfile(false), false)
+
+	if !strings.Contains(args[3], "tap,id=mgmt,ifname=tap0") {
+		t.Fatalf("management netdev should use tap0, got %q", args[3])
+	}
+}
+
+func TestQemuMgmtNICEnvPassthroughOverrideFalse(t *testing.T) {
+	t.Setenv(boxenconstants.EnvClabMgmtPassthrough, "false")
+
+	args := qemuMgmtNIC(testQemuProfile(true), false)
+
+	if !strings.Contains(args[3], "user,id=mgmt") {
+		t.Fatalf("management netdev should use user networking, got %q", args[3])
+	}
+}
+
+func TestQemuMgmtNICPackagingFallback(t *testing.T) {
+	t.Setenv(boxenconstants.EnvClabMgmtPassthrough, "true")
+
+	args := qemuMgmtNIC(testQemuProfile(true), true)
+
+	if !strings.Contains(args[3], "user,id=mgmt") {
+		t.Fatalf("packaging netdev should use user networking, got %q", args[3])
+	}
+}
+
+func testQemuProfile(managementPassthrough bool) *Profile {
+	return &Profile{
+		Name: "test",
+		VirtualMachine: &VirtualMachine{
+			NicType:               "virtio-net-pci",
+			ManagementPassthrough: managementPassthrough,
+			NatPorts: []NatPort{
+				{
+					Type:      NatTypeTCP,
+					LocalPort: 22,
+				},
+			},
+		},
+	}
+}

--- a/profile/virtualmachine.go
+++ b/profile/virtualmachine.go
@@ -1,6 +1,12 @@
 package profile
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	boxenconstants "github.com/carlmontanari/boxen/constants"
+)
 
 // VirtualMachine defines the qemu settings/profile for an endpoint, this will generally come from
 // yaml "profile" manifests that we load or users provide to tell us how to configure the vm.
@@ -95,4 +101,19 @@ type NatPort struct {
 	Type         NatType `yaml:"type"`
 	LocalPort    uint32  `yaml:"localPort"`
 	ExternalPort uint32  `yaml:"externalPort"`
+}
+
+// EffectiveManagementPassthrough resolves the transparent management mode.
+// The containerlab environment override wins over the profile default, matching vrnetlab.
+func (v *VirtualMachine) EffectiveManagementPassthrough() bool {
+	envValue, ok := os.LookupEnv(boxenconstants.EnvClabMgmtPassthrough)
+	if ok && envValue != "" {
+		return strings.ToLower(envValue) == "true"
+	}
+
+	if v == nil {
+		return false
+	}
+
+	return v.ManagementPassthrough
 }

--- a/profile/virtualmachine.go
+++ b/profile/virtualmachine.go
@@ -103,9 +103,10 @@ type NatPort struct {
 	ExternalPort uint32  `yaml:"externalPort"`
 }
 
-// EffectiveManagementPassthrough resolves the transparent management mode.
-// The containerlab environment override wins over the profile default, matching vrnetlab.
-func (v *VirtualMachine) EffectiveManagementPassthrough() bool {
+// IsManagementPassthroughEnabled resolves the transparent management mode.
+// The CLAB_MGMT_PASSTHROUGH environment var wins over the profile default,
+// allowing a user to override the profile's setting during runtime.
+func (v *VirtualMachine) IsManagementPassthroughEnabled() bool {
 	envValue, ok := os.LookupEnv(boxenconstants.EnvClabMgmtPassthrough)
 	if ok && envValue != "" {
 		return strings.ToLower(envValue) == "true"

--- a/profile/virtualmachine.go
+++ b/profile/virtualmachine.go
@@ -1,7 +1,6 @@
 package profile
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
@@ -65,26 +64,21 @@ type QemuConfigField struct {
 	Val       []QemuConfigVal `yaml:"val"`
 }
 
-// Apply applies this ConfigField to the list of qemu commands in `o`.
-func (c QemuConfigField) Apply(f *Formatters, isPackaging bool, o []string) ([]string, error) {
+// Apply appends this ConfigField's content to the list of qemu commands in `o`, gated by whether
+// the field applies to the current packaging/run phase.
+func (c QemuConfigField) Apply(isPackaging bool, o []string) []string {
 	if (isPackaging && c.OnPackage) || (!isPackaging && c.OnRun) {
 		for _, v := range c.Val {
-			fs, err := f.UnpackFormatters(v.Formatters)
-			if err != nil {
-				return nil, err
-			}
-
-			o = append(o, fmt.Sprintf(v.Content, fs...))
+			o = append(o, v.Content)
 		}
 	}
 
-	return o, nil
+	return o
 }
 
-// QemuConfigVal represents an extra string and any formatters that should be applied to it.
+// QemuConfigVal represents an extra string to add to the qemu command.
 type QemuConfigVal struct {
-	Content    string   `yaml:"content"`
-	Formatters []string `yaml:"formatters"`
+	Content string `yaml:"content"`
 }
 
 // NatType is an enum-ish value for the type of NAT port -- tcp or udp.

--- a/util/env.go
+++ b/util/env.go
@@ -3,6 +3,7 @@ package util
 import (
 	"os"
 	"strconv"
+	"strings"
 )
 
 // GetEnvStrOrDefault returns the value of the environment variable k or the default d if the value
@@ -30,4 +31,11 @@ func GetEnvIntOrDefault(k string, d int) int {
 	}
 
 	return d
+}
+
+// EnvBoolTrue returns true if the environment variable k is set to "true", false otherwise.
+func EnvBoolTrue(k string) bool {
+	v := GetEnvStrOrDefault(k, "")
+
+	return strings.ToLower(v) == "true"
 }

--- a/util/env.go
+++ b/util/env.go
@@ -1,9 +1,12 @@
 package util
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
+
+	boxenconstants "github.com/carlmontanari/boxen/constants"
 )
 
 // GetEnvStrOrDefault returns the value of the environment variable k or the default d if the value
@@ -38,4 +41,22 @@ func EnvBoolTrue(k string) bool {
 	v := GetEnvStrOrDefault(k, "")
 
 	return strings.ToLower(v) == "true"
+}
+
+// ClabIntfPrefix returns the containerlab interface name prefix (e.g. "eth"),
+// honoring the CLAB_INTF_PREFIX environment variable when set.
+func ClabIntfPrefix() string {
+	return GetEnvStrOrDefault(boxenconstants.EnvClabIntfPrefix, "eth")
+}
+
+// ClabIntfName returns the containerlab interface name for the given index
+// (e.g. "eth0"), honoring the CLAB_INTF_PREFIX environment variable.
+func ClabIntfName(idx int) string {
+	return fmt.Sprintf("%s%d", ClabIntfPrefix(), idx)
+}
+
+// ClabMgmtIntfName returns the containerlab management interface name. The
+// management interface is always the zero-indexed interface (e.g. "eth0").
+func ClabMgmtIntfName() string {
+	return ClabIntfName(0)
 }


### PR DESCRIPTION
the `.virtualMachine.managementPassthrough: bool` drives the mgmt mode.

```
  virtualMachine:
    cpuEmulation: host
    memory: 4096
    cpuCores: 2
    serialPortCount: 1
    nicType: virtio-net-pci
    nicCount: 16
    nicPerBus: 26
    managementPassthrough: true
```

No natPorts required.

The packaing process still uses the qemu host fwd, as the container interface is not in the picture yet.

The run process takes the ipv4/6 address from the eth0 uses another tc to stitch all traffic to<->from

Since the ip addresses are the runtime info, the `write` step is refactored to use the go template language to minimize the prolifiration of formatters:

```yaml
      - type: write
        write:
          content: |
            nv unset interface eth0 ipv4 dhcp-client
            nv set interface eth0 ipv4 address {{ .mgmtIPv4 }}
            nv set interface eth0 ipv4 gateway {{ .mgmtGatewayIPv4 }}
            nv set interface eth0 ipv6 address {{ .mgmtIPv6 }}
            nv set interface eth0 ipv6 gateway {{ .mgmtGatewayIPv6 }}
            nv set system gnmi-server state enabled
            nv set system gnmi-server listening-address {{ .mgmtIPv4Address }}
            nv set system gnmi-server listening-address {{ .mgmtIPv6Address }}
            nv set system snmp-server listening-address {{ .mgmtIPv4Address }} vrf mgmt
            nv set system snmp-server listening-address {{ .mgmtIPv6Address }} vrf mgmt
            nv set system snmp-server readonly-community public access {{ .mgmtIPv4Network }}
            nv set system snmp-server readonly-community public access {{ .mgmtIPv6Network }}
```

it is currenty  a static set of template vars. Can be later made user defined via a vars struct maybe...

The template vars can be used in the packaging step as well, they will be resolved to the default values like (10.0.0.15 for v4) and boxen is instructed to use these defaults based on the last bool arg in formatters init:

```
boxenprofile.NewFormatters("", "", "", "", a.p, true)
```

```
switch {
case f.isPackaging:
	f.management = defaultManagementFormatters()
case f.p == nil || f.p.VirtualMachine == nil:
	f.management = defaultManagementFormatters()
case !f.p.VirtualMachine.EffectiveManagementPassthrough():
	f.management = defaultManagementFormatters()
case envBoolTrue(boxenconstants.EnvClabMgmtDHCP):
	f.management = dhcpManagementFormatters()
default:
	management, err := runtimeManagementFormatters(context.Background())
```

`true` means it is a packaging step and the default static SLIRP QEMU addresses are to be used.

close #61 