### PR TITLE
Healthcheck container status

### DIFF
--- a/agent/health.go
+++ b/agent/health.go
@@ -1,0 +1,37 @@
+package agent
+
+import (
+	"errors"
+	"os"
+	"strings"
+
+	boxenconstants "github.com/carlmontanari/boxen/constants"
+)
+
+const healthFilePermissions = 0o644
+
+// writeHealth writes the given status string to the health file consulted by the
+// container healthcheck.
+func (a *Agent) writeHealth(status string) error {
+	return os.WriteFile(
+		boxenconstants.HealthFilePath,
+		[]byte(status),
+		healthFilePermissions,
+	)
+}
+
+// Health implements the container healthcheck. It returns nil (exit 0, healthy)
+// only when the health file's status field is "0", otherwise an error (exit 1).
+func Health() error {
+	b, err := os.ReadFile(boxenconstants.HealthFilePath)
+	if err != nil {
+		return err
+	}
+
+	fields := strings.Fields(string(b))
+	if len(fields) == 0 || fields[0] != "0" {
+		return errors.New("unhealthy")
+	}
+
+	return nil
+}

--- a/agent/run.go
+++ b/agent/run.go
@@ -60,6 +60,12 @@ func (a *Agent) Run(
 }
 
 func (a *Agent) startRun(ctx context.Context, errs chan error) {
+	// mark the node as booting so the healthcheck reports unhealthy until the run
+	// process completes successfully; best-effort, non-fatal.
+	if err := a.writeHealth(boxenconstants.HealthStatusBooting); err != nil {
+		a.l.Error("failed writing booting health status", "error", err.Error())
+	}
+
 	err := a.runClabNICProvisionDelay(ctx)
 	if err != nil {
 		errs <- err
@@ -121,6 +127,15 @@ func (a *Agent) startRun(ctx context.Context, errs chan error) {
 
 		return
 	}
+
+	err = a.writeHealth(boxenconstants.HealthStatusRunning)
+	if err != nil {
+		errs <- err
+
+		return
+	}
+
+	a.l.Info("run process completed successfully; marked healthy")
 
 	<-ctx.Done()
 

--- a/build/agent.Dockerfile
+++ b/build/agent.Dockerfile
@@ -60,4 +60,8 @@ COPY build/scrapligo_definition.yaml .scrapligo_definition.yaml
 COPY --from=builder /root/.cache/scrapli/libscrapli.so /boxen/.libscrapli.so
 COPY --from=builder /boxen/out/boxen /boxen/boxen
 
+# reports healthy once boxen run writes 0 running to /health
+HEALTHCHECK --interval=5s --timeout=5s --start-period=5m --retries=1 \
+    CMD ["/boxen/boxen", "health"]
+
 ENTRYPOINT ["/boxen/boxen", "package"]

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,6 +27,7 @@ func main() {
 			buildCommand(),
 			packageCommand(),
 			runCommand(),
+			healthCommand(),
 		},
 	}
 
@@ -206,6 +207,16 @@ func runCommand() *urfavecli.Command {
 				cmd.String(boxenconstants.FlagContainerlabHostname),
 				cmd.String(boxenconstants.FlagContainerlabConnectionMode),
 			)
+		},
+	}
+}
+
+func healthCommand() *urfavecli.Command {
+	return &urfavecli.Command{
+		Name:  "health",
+		Usage: "container healthcheck; exits 0 when the node reports running",
+		Action: func(_ context.Context, _ *urfavecli.Command) error {
+			return boxenagent.Health()
 		},
 	}
 }

--- a/constants/containerlab.go
+++ b/constants/containerlab.go
@@ -17,4 +17,11 @@ const (
 	EnvClabQemuAdditionalArgs = "QEMU_ADDITIONAL_ARGS"
 
 	StartupConfigFilePath = "/config/startup-config.cfg"
+
+	// HealthFilePath is read by the container healthcheck; its first whitespace
+	// separated field is the status code (0 == healthy), vrnetlab-compatible.
+	HealthFilePath = "/health"
+
+	HealthStatusBooting = "1 booting"
+	HealthStatusRunning = "0 running"
 )


### PR DESCRIPTION
Adds healtcheck support for the boxen-built images. Keeps parity with vrnetlab when it comes to the healthcheck procedure - the internal process checks the contents of the `/health` file and if the first token is `0` then the status becomes `healthy`.

The status is set when the `run` stage successfully completes.

When we enter the `run` stage we write to the `/health` file the `1 booting`.

This container status is used by Containerlab as a gate towards an "accessible" NOS.